### PR TITLE
[codex] Add macOS arm64 build entrypoint

### DIFF
--- a/.github/workflows/macos-build-check.yml
+++ b/.github/workflows/macos-build-check.yml
@@ -1,0 +1,39 @@
+name: macOS Build Script Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/macos-build-check.yml'
+      - 'README.md'
+      - 'build/README.md'
+      - 'build/macos/**'
+  push:
+    paths:
+      - '.github/workflows/macos-build-check.yml'
+      - 'README.md'
+      - 'build/README.md'
+      - 'build/macos/**'
+
+jobs:
+  macos-build-script:
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt
+        run: |
+          brew list qt@5 >/dev/null 2>&1 || brew install qt@5 || brew install qt
+
+      - name: Check shell syntax
+        run: bash -n build/macos/build.sh
+
+      - name: Run macOS preflight
+        run: |
+          export EO_SKIP_SPACE_CHECK=1
+          ./build/macos/build.sh --check
+
+      - name: Run dry-run build plan
+        run: |
+          export EO_SKIP_SPACE_CHECK=1
+          ./build/macos/build.sh --dry-run arm64

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ Desktop Editors contain the following components:
 * [web-apps](https://github.com/Euro-Office/web-apps) - the frontend for [Document Server][1] which is a part of Desktop Editors that allows the user to create, edit, save and export text, spreadsheet and presentation documents using the common interface of a document editor.
 * [dictionaries](https://github.com/Euro-Office/dictionaries) - the dictionaries of various languages used for spellchecking in Desktop Editors.
 
+## Build Instructions
+
+Linux builds use the existing Docker Buildx Bake flow:
+
+```sh
+cd build
+docker buildx bake
+```
+
+macOS Apple Silicon builds use the host Xcode entrypoint under `build/macos`:
+
+```sh
+cd build
+./macos/build.sh --check
+./macos/build.sh --dry-run arm64
+./macos/build.sh arm64
+```
+
+The macOS output is written to
+`build/deploy/macos/arm64/Euro-Office.app`. Full requirements, environment
+variables, patching notes, and verification steps are documented in
+[`build/README.md`](build/README.md).
+
 ## License 📄
 
 Desktop Editors is licensed under the GNU Affero Public License, version 3.0, ensuring its transparency and commitment to the open-source community.

--- a/build/README.md
+++ b/build/README.md
@@ -44,10 +44,13 @@ cd DesktopEditors/build
 ./macos/build.sh arm64
 ```
 
-The default output is:
+The default macOS output is four standalone Euro-Office apps:
 
 ```text
-DesktopEditors/build/deploy/macos/arm64/Euro-Office.app
+DesktopEditors/build/deploy/macos/arm64/Euro-Office Text.app
+DesktopEditors/build/deploy/macos/arm64/Euro-Office Spreadsheet.app
+DesktopEditors/build/deploy/macos/arm64/Euro-Office Presentation.app
+DesktopEditors/build/deploy/macos/arm64/Euro-Office PDF.app
 ```
 
 The macOS build currently targets Apple Silicon first. Intel and universal
@@ -78,6 +81,7 @@ MIN_FREE_GIB=150                 # minimum free disk space check
 EO_SKIP_SPACE_CHECK=1            # bypass the free-space guard
 QT_DIR=/path/to/qt-root          # contains <version>/macos/bin/qmake or <version>/clang_64/bin/qmake
 DESKTOP_APPS_DIR=/path/to/desktop-apps
+EO_MACOS_PRODUCTS=split          # split, suite, all, or comma list: text,spreadsheet,presentation,pdf
 BUILD_TOOLS_REV=<commit>         # ONLYOFFICE/build_tools revision
 CODESIGNING_IDENTITY="Developer ID Application: ..."
 DEVELOPMENT_TEAM=<team-id>

--- a/build/README.md
+++ b/build/README.md
@@ -76,7 +76,7 @@ variables:
 ```sh
 MIN_FREE_GIB=150                 # minimum free disk space check
 EO_SKIP_SPACE_CHECK=1            # bypass the free-space guard
-QT_DIR=/path/to/qt-layout        # contains macos/bin/qmake or clang_64/bin/qmake
+QT_DIR=/path/to/qt-root          # contains <version>/macos/bin/qmake or <version>/clang_64/bin/qmake
 DESKTOP_APPS_DIR=/path/to/desktop-apps
 BUILD_TOOLS_REV=<commit>         # ONLYOFFICE/build_tools revision
 CODESIGNING_IDENTITY="Developer ID Application: ..."
@@ -84,13 +84,65 @@ DEVELOPMENT_TEAM=<team-id>
 EO_SKIP_LAUNCH=1                 # skip the local launch smoke test
 ```
 
+If `QT_DIR` points at a root directory and Homebrew Qt is available, the script
+creates a build-tools compatible layout such as `<QT_DIR>/5.15.18/macos`.
+
 `DESKTOP_APPS_DIR` is optional. It is useful while the matching `desktop-apps`
 macOS branding branch is still under review; after that branch is merged,
 `DesktopEditors` can point its `desktop-apps` submodule at the upstream commit.
+Upstream `build_tools` still reads `desktop-apps/common/loginpage` from the
+`DesktopEditors` repo root, so the wrapper temporarily links the external
+checkout into that submodule path during the build and restores the empty path
+on exit. Xcode build phases also resolve `../../build_tools`, `../../core`,
+`../../desktop-sdk`, and the dictionaries folder from the `desktop-apps/macos`
+checkout, so the wrapper temporarily links those sibling paths under
+`<desktop-apps-parent>` back to the matching `DesktopEditors` directories while
+using an external checkout.
 
 Without a Developer ID identity the app build is ad-hoc signed and suitable for
 local testing. Release DMG signing and notarization remain gated on Developer ID
 and notarization credentials.
+
+Some upstream `build_tools` steps still call `python`. When macOS only provides
+`python3`, `build/macos/build.sh` adds a local `python` shim under
+`build/deploy/macos/tools/bin` for the duration of the build.
+
+The JavaScript build steps call `grunt` directly after `npm install`. The macOS
+wrapper adds a local `grunt` shim under `build/deploy/macos/tools/bin` that
+executes the `node_modules/.bin/grunt` from the current project directory,
+avoiding any global npm dependency. `build_tools` sets `NODE_ENV=production`
+before those installs, so the wrapper also sets `NPM_CONFIG_INCLUDE=dev`; this
+keeps npm 10+ from omitting Gruntfile helper packages such as `time-grunt`.
+
+The HEIF dependency path in `build_tools` currently requires CMake `>= 3.21`
+and `< 4`. If the host only has CMake 4 or no CMake, the script creates a
+temporary local CMake venv under `build/deploy/macos/tools/cmake-venv`.
+
+The macOS wrapper also exports fetched `katana-parser/src`, `gumbo-parser/src`,
+`hyphen`, and `hunspell/hunspell/src` include paths for the qmake build, which
+otherwise cannot resolve headers such as `katana.h`, `gumbo.h`,
+`hyphen/hnjalloc.h`, and `hunspell/hunspell.h`.
+
+If a previous run left an incomplete Boost output under
+`core/Common/3dParty/boost/build/mac_arm64`, the wrapper removes that generated
+directory before calling `build_tools` so `libboost_filesystem.a`,
+`libboost_date_time.a`, and `libboost_regex.a` are rebuilt.
+
+For current Xcode/Clang compatibility with the pinned Boost 1.72 headers, the
+wrapper also patches the local Boost.DateTime `hours`, `minutes`, and `seconds`
+helper constructors that otherwise instantiate Boost numeric conversion paths
+rejected by current Clang.
+
+For current Xcode/Clang compatibility with the pinned Boost 1.72 and iWork
+sources, the wrapper prefetches the generated iWork third-party sources and
+patches a small set of `libetonyek` `numeric_cast<int>` and
+`numeric_cast<unsigned>` calls that otherwise trip Boost MPL enum constant
+evaluation.
+
+The same compatibility pass patches the ODF table border width casts used by
+the PPTX and XLSX converters from `boost::lexical_cast<int>` to a direct cast,
+avoiding another Boost numeric conversion instantiation rejected by current
+Clang.
 
 ### macOS Verification
 

--- a/build/README.md
+++ b/build/README.md
@@ -11,7 +11,8 @@ Clone the repository with submodules:
 git clone --recurse-submodules https://github.com/Euro-Office/DesktopEditors.git
 ```
 
-If the repository was cloned without submodules, initialize them before building:
+If the repository was cloned without submodules, initialize them before
+building:
 
 ```sh
 git submodule update --init --recursive
@@ -41,23 +42,20 @@ Linux bake file:
 ```sh
 cd DesktopEditors/build
 ./macos/build.sh --check
+./macos/build.sh --dry-run arm64
 ./macos/build.sh arm64
 ```
 
-The default macOS output is five standalone AUTARQ-branded apps:
+The default macOS output is one Euro-Office suite application:
 
 ```text
-DesktopEditors/build/deploy/macos/arm64/AUTARQ Write.app
-DesktopEditors/build/deploy/macos/arm64/AUTARQ Sheets.app
-DesktopEditors/build/deploy/macos/arm64/AUTARQ Keynote.app
-DesktopEditors/build/deploy/macos/arm64/AUTARQ PDF.app
-DesktopEditors/build/deploy/macos/arm64/AUTARQ Draw.app
+DesktopEditors/build/deploy/macos/arm64/Euro-Office.app
 ```
 
 The macOS build currently targets Apple Silicon first. Intel and universal
 builds can be added later using the same `build/macos` layout.
 
-### macOS Requirements
+## macOS Requirements
 
 - macOS on Apple Silicon
 - Xcode command line tools selected with `xcode-select`
@@ -72,86 +70,98 @@ Optional release tooling:
 - Developer ID signing identity for distributable builds
 - notarization credentials for a future signed release flow
 
-### macOS Environment
+## macOS Environment
 
 The script has conservative defaults and can be tuned with environment
 variables:
 
 ```sh
-MIN_FREE_GIB=150                 # minimum free disk space check
-EO_SKIP_SPACE_CHECK=1            # bypass the free-space guard
-QT_DIR=/path/to/qt-root          # contains <version>/macos/bin/qmake or <version>/clang_64/bin/qmake
+MIN_FREE_GIB=150                    # minimum free disk space check
+EO_SKIP_SPACE_CHECK=1               # bypass the free-space guard
+QT_DIR=/path/to/qt-root             # contains <version>/macos/bin/qmake or <version>/clang_64/bin/qmake
 DESKTOP_APPS_DIR=/path/to/desktop-apps
-EO_MACOS_PRODUCTS=split          # split, suite, all, or comma list: text,spreadsheet,presentation,pdf,visio
-BUILD_TOOLS_REV=<commit>         # ONLYOFFICE/build_tools revision
+EO_MACOS_PRODUCTS=suite             # this Euro-Office branch exports one suite app
+BUILD_TOOLS_REV_FILE=build/macos/build_tools.sha
+BUILD_TOOLS_REV=<commit>            # explicit override for ONLYOFFICE/build_tools
+EO_ALLOW_GIT_HTTPS_FALLBACK=1       # opt in to git@github.com: -> https://github.com/ rewrite
 CODESIGNING_IDENTITY="Developer ID Application: ..."
 DEVELOPMENT_TEAM=<team-id>
-EO_SKIP_LAUNCH=1                 # skip the local launch smoke test
+EO_SKIP_LAUNCH=1                    # skip the local launch smoke test
 ```
 
-If `QT_DIR` points at a root directory and Homebrew Qt is available, the script
-creates a build-tools compatible layout such as `<QT_DIR>/5.15.18/macos`.
-
-`DESKTOP_APPS_DIR` is optional. It is useful while the matching `desktop-apps`
-macOS branding branch is still under review; after that branch is merged,
-`DesktopEditors` can point its `desktop-apps` submodule at the upstream commit.
-Upstream `build_tools` still reads `desktop-apps/common/loginpage` from the
-`DesktopEditors` repo root, so the wrapper temporarily links the external
-checkout into that submodule path during the build and restores the empty path
-on exit. Xcode build phases also resolve `../../build_tools`, `../../core`,
-`../../desktop-sdk`, and the dictionaries folder from the `desktop-apps/macos`
-checkout, so the wrapper temporarily links those sibling paths under
-`<desktop-apps-parent>` back to the matching `DesktopEditors` directories while
-using an external checkout.
+`build/macos/build_tools.sha` pins the default `ONLYOFFICE/build_tools`
+revision. Use `BUILD_TOOLS_REV` only for local experiments or while updating
+that pin in a reviewable change.
 
 Without a Developer ID identity the app build is ad-hoc signed and suitable for
 local testing. Release DMG signing and notarization remain gated on Developer ID
 and notarization credentials.
 
+## macOS Dry Run
+
+`./macos/build.sh --dry-run arm64` does not mutate the checkout. It prints the
+suite app output path, pinned `build_tools` revision, Xcode project, Qt layout
+decision, submodule URL behavior, and any temporary symlinks that would be used
+when `DESKTOP_APPS_DIR` points at an external checkout.
+
+This is useful before running the full native build, because upstream
+`build_tools` still expects `desktop-apps/common/loginpage` under the
+`DesktopEditors` root, while Xcode build phases resolve sibling paths such as
+`../../build_tools`, `../../core`, `../../desktop-sdk`, and
+`../../dictionaries` from the `desktop-apps/macos` checkout. The wrapper creates
+those symlinks only for the build and removes them on exit.
+
+The script does not change contributor git URL configuration by default. If a
+local environment cannot fetch `git@github.com:` submodules, set
+`EO_ALLOW_GIT_HTTPS_FALLBACK=1` to opt in to the local HTTPS rewrite.
+
+## macOS Compatibility Patches
+
+Current Xcode/Clang rejects a few older Boost 1.72 numeric conversion paths used
+by the pinned native dependencies. The wrapper applies reviewable patch files
+from `build/macos/patches` with `git apply --unidiff-zero`, records the applied
+patches, and reverts them during normal cleanup:
+
+- `boost-date-time-duration.patch`
+- `boost-date-time-duration-installed.patch`
+- `libetonyek-clang-compat.patch`
+- `odf-border-width-clang-compat.patch`
+
+If the patch is already present, the script detects that with
+`git apply --reverse --check` and continues without dirtying the tree again.
+
+## macOS Local Tooling Notes
+
 Some upstream `build_tools` steps still call `python`. When macOS only provides
-`python3`, `build/macos/build.sh` adds a local `python` shim under
+`python3`, the wrapper adds a local `python` shim under
 `build/deploy/macos/tools/bin` for the duration of the build.
 
 The JavaScript build steps call `grunt` directly after `npm install`. The macOS
 wrapper adds a local `grunt` shim under `build/deploy/macos/tools/bin` that
 executes the `node_modules/.bin/grunt` from the current project directory,
 avoiding any global npm dependency. `build_tools` sets `NODE_ENV=production`
-before those installs, so the wrapper also sets `NPM_CONFIG_INCLUDE=dev`; this
-keeps npm 10+ from omitting Gruntfile helper packages such as `time-grunt`.
+before those installs, so the wrapper sets `NPM_CONFIG_INCLUDE=dev` and
+`NPM_CONFIG_PRODUCTION=false`; this keeps npm from omitting Gruntfile helper
+packages such as `time-grunt`.
 
 The HEIF dependency path in `build_tools` currently requires CMake `>= 3.21`
-and `< 4`. If the host only has CMake 4 or no CMake, the script creates a
-temporary local CMake venv under `build/deploy/macos/tools/cmake-venv`.
+and `< 4`. If the host only has CMake 4 or no CMake, the script creates a local
+CMake venv under `build/deploy/macos/tools/cmake-venv`.
 
-The macOS wrapper also exports fetched `katana-parser/src`, `gumbo-parser/src`,
-`hyphen`, and `hunspell/hunspell/src` include paths for the qmake build, which
-otherwise cannot resolve headers such as `katana.h`, `gumbo.h`,
-`hyphen/hnjalloc.h`, and `hunspell/hunspell.h`.
+If `QT_DIR` points at a root directory and Homebrew Qt is available, the script
+creates a build-tools compatible layout such as `<QT_DIR>/5.15.18/macos`.
 
-If a previous run left an incomplete Boost output under
-`core/Common/3dParty/boost/build/mac_arm64`, the wrapper removes that generated
-directory before calling `build_tools` so `libboost_filesystem.a`,
-`libboost_date_time.a`, and `libboost_regex.a` are rebuilt.
-
-For current Xcode/Clang compatibility with the pinned Boost 1.72 headers, the
-wrapper also patches the local Boost.DateTime `hours`, `minutes`, and `seconds`
-helper constructors that otherwise instantiate Boost numeric conversion paths
-rejected by current Clang.
-
-For current Xcode/Clang compatibility with the pinned Boost 1.72 and iWork
-sources, the wrapper prefetches the generated iWork third-party sources and
-patches a small set of `libetonyek` `numeric_cast<int>` and
-`numeric_cast<unsigned>` calls that otherwise trip Boost MPL enum constant
-evaluation.
-
-The same compatibility pass patches the ODF table border width casts used by
-the PPTX and XLSX converters from `boost::lexical_cast<int>` to a direct cast,
-avoiding another Boost numeric conversion instantiation rejected by current
-Clang.
-
-### macOS Verification
+## macOS Verification
 
 `build/macos/build.sh arm64` verifies the generated application by checking the
 main executable architecture and running strict codesign verification. Unless
-`EO_SKIP_LAUNCH=1` is set, it also opens the app once as a local launch smoke
-test.
+`EO_SKIP_LAUNCH=1` is set, it opens the app once and waits up to 30 seconds for
+the app process before quitting it again.
+
+The lightweight GitHub Actions check for this path runs:
+
+```sh
+bash -n build/macos/build.sh
+./build/macos/build.sh --check
+./build/macos/build.sh --dry-run arm64
+```

--- a/build/README.md
+++ b/build/README.md
@@ -44,14 +44,14 @@ cd DesktopEditors/build
 ./macos/build.sh arm64
 ```
 
-The default macOS output is five standalone Euro-Office apps:
+The default macOS output is five standalone AUTARQ-branded apps:
 
 ```text
-DesktopEditors/build/deploy/macos/arm64/Euro-Office Text.app
-DesktopEditors/build/deploy/macos/arm64/Euro-Office Spreadsheet.app
-DesktopEditors/build/deploy/macos/arm64/Euro-Office Presentation.app
-DesktopEditors/build/deploy/macos/arm64/Euro-Office PDF.app
-DesktopEditors/build/deploy/macos/arm64/Euro-Office Visio.app
+DesktopEditors/build/deploy/macos/arm64/AUTARQ Write.app
+DesktopEditors/build/deploy/macos/arm64/AUTARQ Sheets.app
+DesktopEditors/build/deploy/macos/arm64/AUTARQ Keynote.app
+DesktopEditors/build/deploy/macos/arm64/AUTARQ PDF.app
+DesktopEditors/build/deploy/macos/arm64/AUTARQ Draw.app
 ```
 
 The macOS build currently targets Apple Silicon first. Intel and universal

--- a/build/README.md
+++ b/build/README.md
@@ -1,25 +1,100 @@
-# Desktop Editors
+# Euro-Office Desktop Editors Builds
 
-Docker image where we are experimenting with building the OnlyOffice Desktop Editors.
+This directory contains the reproducible build entrypoints for Euro-Office
+Desktop Editors.
 
-## Building the Image
+## Clone
 
-First, clone the repositories for the core-fonts, sdkjs, web-apps, and server components:
+Clone the repository with submodules:
 
 ```sh
 git clone --recurse-submodules https://github.com/Euro-Office/DesktopEditors.git
 ```
 
-If the repo was cloned without --recurse-submodules, initialize and download the submodules with:
+If the repository was cloned without submodules, initialize them before building:
+
 ```sh
 git submodule update --init --recursive
 ```
 
-Then, you can build the full image by running:
+## Linux
+
+Linux builds continue to use Docker Buildx Bake:
 
 ```sh
 cd DesktopEditors/build
 docker buildx bake
 ```
 
-After it finishes the desktop editors will be in build/deploy/desktop
+The exported desktop build is written to:
+
+```text
+DesktopEditors/build/deploy/desktop
+```
+
+## macOS
+
+macOS builds must run on a macOS host with Xcode installed. Xcode application
+builds are not wrapped in Docker; the host build entrypoint lives next to the
+Linux bake file:
+
+```sh
+cd DesktopEditors/build
+./macos/build.sh --check
+./macos/build.sh arm64
+```
+
+The default output is:
+
+```text
+DesktopEditors/build/deploy/macos/arm64/Euro-Office.app
+```
+
+The macOS build currently targets Apple Silicon first. Intel and universal
+builds can be added later using the same `build/macos` layout.
+
+### macOS Requirements
+
+- macOS on Apple Silicon
+- Xcode command line tools selected with `xcode-select`
+- Python 3
+- Git
+- Qt available through `QT_DIR` or a Homebrew Qt install
+- Enough free space for native dependencies and the Xcode build
+
+Optional release tooling:
+
+- `gh` for PR and release workflows
+- Developer ID signing identity for distributable builds
+- notarization credentials for a future signed release flow
+
+### macOS Environment
+
+The script has conservative defaults and can be tuned with environment
+variables:
+
+```sh
+MIN_FREE_GIB=150                 # minimum free disk space check
+EO_SKIP_SPACE_CHECK=1            # bypass the free-space guard
+QT_DIR=/path/to/qt-layout        # contains macos/bin/qmake or clang_64/bin/qmake
+DESKTOP_APPS_DIR=/path/to/desktop-apps
+BUILD_TOOLS_REV=<commit>         # ONLYOFFICE/build_tools revision
+CODESIGNING_IDENTITY="Developer ID Application: ..."
+DEVELOPMENT_TEAM=<team-id>
+EO_SKIP_LAUNCH=1                 # skip the local launch smoke test
+```
+
+`DESKTOP_APPS_DIR` is optional. It is useful while the matching `desktop-apps`
+macOS branding branch is still under review; after that branch is merged,
+`DesktopEditors` can point its `desktop-apps` submodule at the upstream commit.
+
+Without a Developer ID identity the app build is ad-hoc signed and suitable for
+local testing. Release DMG signing and notarization remain gated on Developer ID
+and notarization credentials.
+
+### macOS Verification
+
+`build/macos/build.sh arm64` verifies the generated application by checking the
+main executable architecture and running strict codesign verification. Unless
+`EO_SKIP_LAUNCH=1` is set, it also opens the app once as a local launch smoke
+test.

--- a/build/README.md
+++ b/build/README.md
@@ -44,13 +44,14 @@ cd DesktopEditors/build
 ./macos/build.sh arm64
 ```
 
-The default macOS output is four standalone Euro-Office apps:
+The default macOS output is five standalone Euro-Office apps:
 
 ```text
 DesktopEditors/build/deploy/macos/arm64/Euro-Office Text.app
 DesktopEditors/build/deploy/macos/arm64/Euro-Office Spreadsheet.app
 DesktopEditors/build/deploy/macos/arm64/Euro-Office Presentation.app
 DesktopEditors/build/deploy/macos/arm64/Euro-Office PDF.app
+DesktopEditors/build/deploy/macos/arm64/Euro-Office Visio.app
 ```
 
 The macOS build currently targets Apple Silicon first. Intel and universal
@@ -81,7 +82,7 @@ MIN_FREE_GIB=150                 # minimum free disk space check
 EO_SKIP_SPACE_CHECK=1            # bypass the free-space guard
 QT_DIR=/path/to/qt-root          # contains <version>/macos/bin/qmake or <version>/clang_64/bin/qmake
 DESKTOP_APPS_DIR=/path/to/desktop-apps
-EO_MACOS_PRODUCTS=split          # split, suite, all, or comma list: text,spreadsheet,presentation,pdf
+EO_MACOS_PRODUCTS=split          # split, suite, all, or comma list: text,spreadsheet,presentation,pdf,visio
 BUILD_TOOLS_REV=<commit>         # ONLYOFFICE/build_tools revision
 CODESIGNING_IDENTITY="Developer ID Application: ..."
 DEVELOPMENT_TEAM=<team-id>

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -5,8 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${BUILD_DIR}/.." && pwd)"
 
-PRODUCT_NAME="${PRODUCT_NAME:-Euro-Office}"
+PRODUCT_FAMILY_NAME="${PRODUCT_FAMILY_NAME:-Euro-Office}"
+PRODUCT_NAME="${PRODUCT_NAME:-${PRODUCT_FAMILY_NAME}}"
 BUNDLE_ID="${PRODUCT_BUNDLE_IDENTIFIER:-org.euro-office.desktopeditors}"
+MACOS_PRODUCTS="${EO_MACOS_PRODUCTS:-split}"
 SCHEME="${SCHEME:-ONLYOFFICE-arm}"
 ARCH="${1:-}"
 BUILD_TOOLS_REV="${BUILD_TOOLS_REV:-c5f6c2e02b50dfcc5c53a207f9a6cde84896de91}"
@@ -26,6 +28,8 @@ XCODE_PROJECT="${DESKTOP_APPS_DIR}/macos/ONLYOFFICE.xcodeproj"
 PREFLIGHT_FAILURES=0
 EXTERNAL_DESKTOP_APPS_LINK=""
 EXTERNAL_REPO_SIBLING_LINKS=()
+BUILT_XCODE_APP=""
+STAGED_APPS=()
 
 cleanup_external_desktop_apps_link() {
   if [[ -n "${EXTERNAL_DESKTOP_APPS_LINK}" && -L "${EXTERNAL_DESKTOP_APPS_LINK}" ]]; then
@@ -55,6 +59,7 @@ Environment:
   EO_SKIP_SPACE_CHECK=1
   QT_DIR=/path/to/qt-root
   BUILD_TOOLS_REV=${BUILD_TOOLS_REV}
+  EO_MACOS_PRODUCTS=split|suite|text,spreadsheet,presentation,pdf
   CODESIGNING_IDENTITY="Developer ID Application: ..."
   DEVELOPMENT_TEAM=<team-id>
   EO_SKIP_LAUNCH=1
@@ -764,6 +769,157 @@ build_native_payload() {
   info "native payload ready: ${payload_dir}"
 }
 
+codesign_identity() {
+  local sign_identity="${CODESIGNING_IDENTITY:-${CODE_SIGN_IDENTITY:--}}"
+  if [[ -z "${sign_identity}" ]]; then
+    sign_identity="-"
+  fi
+
+  printf '%s\n' "${sign_identity}"
+}
+
+entitlements_file() {
+  local entitlements="${DESKTOP_APPS_DIR}/macos/ONLYOFFICE/Resources/${SCHEME}/ONLYOFFICE.entitlements"
+  if [[ -f "${entitlements}" ]]; then
+    printf '%s\n' "${entitlements}"
+  fi
+}
+
+selected_products() {
+  case "${MACOS_PRODUCTS}" in
+    split)
+      printf '%s\n' text spreadsheet presentation pdf
+      ;;
+    suite)
+      printf '%s\n' suite
+      ;;
+    all)
+      printf '%s\n' suite text spreadsheet presentation pdf
+      ;;
+    *)
+      printf '%s\n' "${MACOS_PRODUCTS//,/ }" | xargs -n1
+      ;;
+  esac
+}
+
+product_app_name() {
+  case "$1" in
+    text) printf '%s Text\n' "${PRODUCT_FAMILY_NAME}" ;;
+    spreadsheet) printf '%s Spreadsheet\n' "${PRODUCT_FAMILY_NAME}" ;;
+    presentation) printf '%s Presentation\n' "${PRODUCT_FAMILY_NAME}" ;;
+    pdf) printf '%s PDF\n' "${PRODUCT_FAMILY_NAME}" ;;
+    suite) printf '%s\n' "${PRODUCT_NAME}" ;;
+    *) fail "unknown macOS product component: $1" ;;
+  esac
+}
+
+product_executable_name() {
+  case "$1" in
+    text) printf 'EuroOfficeText\n' ;;
+    spreadsheet) printf 'EuroOfficeSpreadsheet\n' ;;
+    presentation) printf 'EuroOfficePresentation\n' ;;
+    pdf) printf 'EuroOfficePDF\n' ;;
+    suite) printf '%s\n' "${PRODUCT_NAME}" ;;
+    *) fail "unknown macOS product component: $1" ;;
+  esac
+}
+
+product_bundle_id() {
+  case "$1" in
+    text|spreadsheet|presentation|pdf) printf '%s.%s\n' "${BUNDLE_ID}" "$1" ;;
+    suite) printf '%s\n' "${BUNDLE_ID}" ;;
+    *) fail "unknown macOS product component: $1" ;;
+  esac
+}
+
+product_url_scheme() {
+  case "$1" in
+    text) printf 'euro-office-text\n' ;;
+    spreadsheet) printf 'euro-office-spreadsheet\n' ;;
+    presentation) printf 'euro-office-presentation\n' ;;
+    pdf) printf 'euro-office-pdf\n' ;;
+    suite) printf 'euro-office\n' ;;
+    *) fail "unknown macOS product component: $1" ;;
+  esac
+}
+
+patch_product_info_plist() {
+  local plist="$1"
+  local app_name="$2"
+  local executable_name="$3"
+  local bundle_id="$4"
+  local url_scheme="$5"
+  local component="$6"
+
+  python3 - "${plist}" "${app_name}" "${executable_name}" "${bundle_id}" "${url_scheme}" "${component}" <<'PY'
+import plistlib
+import sys
+
+plist_path, app_name, executable_name, bundle_id, url_scheme, component = sys.argv[1:7]
+
+allowed_extensions = {
+    "text": {
+        "docx", "doc", "odt", "ott", "rtf", "txt", "htm", "html", "dotx",
+        "fodt", "xml", "epub", "mht", "fb2", "pages", "hwp", "hwpx", "hml",
+    },
+    "spreadsheet": {
+        "xlsx", "xls", "ods", "xltx", "ots", "fods", "csv", "xlsm", "xlsb",
+        "numbers",
+    },
+    "presentation": {
+        "ppt", "pptx", "odp", "ppsx", "pps", "potx", "otp", "key", "odg",
+    },
+    "pdf": {
+        "pdf", "docxf", "oform",
+    },
+}
+
+if component not in allowed_extensions:
+    raise SystemExit(f"unsupported product component: {component}")
+
+with open(plist_path, "rb") as plist_file:
+    info = plistlib.load(plist_file)
+
+filtered_document_types = []
+for document_type in info.get("CFBundleDocumentTypes", []):
+    extensions = [ext.lower() for ext in document_type.get("CFBundleTypeExtensions", [])]
+    if any(ext in allowed_extensions[component] for ext in extensions):
+        filtered_document_types.append(document_type)
+
+if not filtered_document_types:
+    raise SystemExit(f"no document types matched product component: {component}")
+
+info["CFBundleName"] = app_name
+info["CFBundleDisplayName"] = app_name
+info["CFBundleExecutable"] = executable_name
+info["CFBundleIdentifier"] = bundle_id
+info["EOProductComponent"] = component
+info["CFBundleURLTypes"] = [{
+    "CFBundleTypeRole": "Editor",
+    "CFBundleURLSchemes": [url_scheme],
+}]
+info["CFBundleDocumentTypes"] = filtered_document_types
+
+with open(plist_path, "wb") as plist_file:
+    plistlib.dump(info, plist_file, fmt=plistlib.FMT_XML, sort_keys=False)
+PY
+}
+
+resign_app() {
+  local app="$1"
+  local sign_identity entitlements
+
+  sign_identity="$(codesign_identity)"
+  entitlements="$(entitlements_file)"
+
+  local codesign_args=(--force --options runtime --sign "${sign_identity}")
+  if [[ -n "${entitlements}" ]]; then
+    codesign_args+=(--entitlements "${entitlements}")
+  fi
+
+  codesign "${codesign_args[@]}" "${app}"
+}
+
 build_xcode_app() {
   mkdir -p "${OUT_DIR}" "${LOG_DIR}"
 
@@ -771,10 +927,8 @@ build_xcode_app() {
     fail "Xcode project not found: ${XCODE_PROJECT}"
   fi
 
-  local sign_identity="${CODESIGNING_IDENTITY:-${CODE_SIGN_IDENTITY:--}}"
-  if [[ -z "${sign_identity}" ]]; then
-    sign_identity="-"
-  fi
+  local sign_identity
+  sign_identity="$(codesign_identity)"
 
   info "building ${PRODUCT_NAME}.app with scheme ${SCHEME}"
   xcodebuild \
@@ -807,18 +961,80 @@ build_xcode_app() {
     fail "Xcode did not produce an app bundle under ${products_dir}"
   fi
 
-  rm -rf "${OUT_DIR}/${PRODUCT_NAME}.app"
-  ditto "${built_app}" "${OUT_DIR}/${PRODUCT_NAME}.app"
-  info "app exported to ${OUT_DIR}/${PRODUCT_NAME}.app"
+  local staging_dir="${BUILD_DIR}/deploy/macos/staging/${ARCH}"
+  rm -rf "${staging_dir}"
+  mkdir -p "${staging_dir}"
+  ditto "${built_app}" "${staging_dir}/${PRODUCT_NAME}.app"
+  BUILT_XCODE_APP="${staging_dir}/${PRODUCT_NAME}.app"
+  info "base app staged at ${BUILT_XCODE_APP}"
+}
+
+stage_product_app() {
+  local component="$1"
+  local app_name executable_name bundle_id url_scheme app old_exe candidate
+
+  app_name="$(product_app_name "${component}")"
+  executable_name="$(product_executable_name "${component}")"
+  bundle_id="$(product_bundle_id "${component}")"
+  url_scheme="$(product_url_scheme "${component}")"
+  app="${OUT_DIR}/${app_name}.app"
+
+  rm -rf "${app}"
+  ditto "${BUILT_XCODE_APP}" "${app}"
+
+  if [[ "${component}" != "suite" ]]; then
+    old_exe="${app}/Contents/MacOS/${PRODUCT_NAME}"
+    if [[ ! -x "${old_exe}" ]]; then
+      old_exe=""
+      for candidate in "${app}/Contents/MacOS"/*; do
+        if [[ -f "${candidate}" && -x "${candidate}" ]]; then
+          old_exe="${candidate}"
+          break
+        fi
+      done
+    fi
+
+    if [[ -z "${old_exe}" || ! -x "${old_exe}" ]]; then
+      fail "app executable missing under ${app}/Contents/MacOS"
+    fi
+
+    mv "${old_exe}" "${app}/Contents/MacOS/${executable_name}"
+    patch_product_info_plist "${app}/Contents/Info.plist" "${app_name}" "${executable_name}" "${bundle_id}" "${url_scheme}" "${component}"
+    resign_app "${app}"
+  fi
+
+  STAGED_APPS+=("${app}")
+  info "app exported to ${app}"
+}
+
+stage_macos_apps() {
+  if [[ -z "${BUILT_XCODE_APP}" || ! -d "${BUILT_XCODE_APP}" ]]; then
+    fail "base Xcode app was not staged"
+  fi
+
+  STAGED_APPS=()
+
+  local component
+  while IFS= read -r component; do
+    [[ -z "${component}" ]] && continue
+    stage_product_app "${component}"
+  done < <(selected_products)
 }
 
 verify_app() {
-  local app="${OUT_DIR}/${PRODUCT_NAME}.app"
-  local exe="${app}/Contents/MacOS/${PRODUCT_NAME}"
+  local app="$1"
+  local plist="${app}/Contents/Info.plist"
+  local app_name executable_name bundle_id exe log_name
 
   if [[ ! -d "${app}" ]]; then
     fail "app bundle missing: ${app}"
   fi
+
+  app_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "${plist}")"
+  executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "${plist}")"
+  bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${plist}")"
+  exe="${app}/Contents/MacOS/${executable_name}"
+  log_name="${app_name// /-}"
 
   if [[ ! -x "${exe}" ]]; then
     local candidate
@@ -835,11 +1051,11 @@ verify_app() {
     fail "app executable missing under ${app}/Contents/MacOS"
   fi
 
-  info "checking executable architecture"
-  file "${exe}" | tee "${LOG_DIR}/file-${PRODUCT_NAME}.log"
+  info "checking executable architecture for ${app_name}"
+  file "${exe}" | tee "${LOG_DIR}/file-${log_name}.log"
   file "${exe}" | grep -q 'arm64' || fail "expected arm64 executable: ${exe}"
 
-  info "verifying code signature"
+  info "verifying code signature for ${app_name}"
   codesign --verify --deep --strict --verbose=4 "${app}"
 
   if [[ "${EO_SKIP_LAUNCH:-0}" == "1" ]]; then
@@ -847,13 +1063,26 @@ verify_app() {
     return
   fi
 
-  info "running launch smoke test"
+  info "running launch smoke test for ${app_name}"
   open -n "${app}"
   sleep 4
-  if ! pgrep -x "${PRODUCT_NAME}" >/dev/null 2>&1; then
-    fail "launch smoke test did not find a running ${PRODUCT_NAME} process"
+  if ! pgrep -f "${app}/Contents/MacOS/${executable_name}" >/dev/null 2>&1; then
+    fail "launch smoke test did not find a running ${app_name} process"
   fi
-  osascript -e "tell application \"${PRODUCT_NAME}\" to quit" >/dev/null 2>&1 || true
+  osascript -e "tell application id \"${bundle_id}\" to quit" >/dev/null 2>&1 || true
+  sleep 1
+  pkill -f "${app}/Contents/MacOS/${executable_name}" >/dev/null 2>&1 || true
+}
+
+verify_apps() {
+  local app
+  if [[ "${#STAGED_APPS[@]}" -eq 0 ]]; then
+    fail "no macOS apps were staged"
+  fi
+
+  for app in "${STAGED_APPS[@]}"; do
+    verify_app "${app}"
+  done
 }
 
 main() {
@@ -876,8 +1105,9 @@ main() {
       ensure_qt_layout
       build_native_payload
       build_xcode_app
-      verify_app
-      info "macOS ${ARCH} build complete: ${OUT_DIR}/${PRODUCT_NAME}.app"
+      stage_macos_apps
+      verify_apps
+      info "macOS ${ARCH} build complete: ${OUT_DIR}"
       ;;
     *)
       usage

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -59,7 +59,7 @@ Environment:
   EO_SKIP_SPACE_CHECK=1
   QT_DIR=/path/to/qt-root
   BUILD_TOOLS_REV=${BUILD_TOOLS_REV}
-  EO_MACOS_PRODUCTS=split|suite|text,spreadsheet,presentation,pdf
+  EO_MACOS_PRODUCTS=split|suite|text,spreadsheet,presentation,pdf,visio
   CODESIGNING_IDENTITY="Developer ID Application: ..."
   DEVELOPMENT_TEAM=<team-id>
   EO_SKIP_LAUNCH=1
@@ -788,13 +788,13 @@ entitlements_file() {
 selected_products() {
   case "${MACOS_PRODUCTS}" in
     split)
-      printf '%s\n' text spreadsheet presentation pdf
+      printf '%s\n' text spreadsheet presentation pdf visio
       ;;
     suite)
       printf '%s\n' suite
       ;;
     all)
-      printf '%s\n' suite text spreadsheet presentation pdf
+      printf '%s\n' suite text spreadsheet presentation pdf visio
       ;;
     *)
       printf '%s\n' "${MACOS_PRODUCTS//,/ }" | xargs -n1
@@ -808,6 +808,7 @@ product_app_name() {
     spreadsheet) printf '%s Spreadsheet\n' "${PRODUCT_FAMILY_NAME}" ;;
     presentation) printf '%s Presentation\n' "${PRODUCT_FAMILY_NAME}" ;;
     pdf) printf '%s PDF\n' "${PRODUCT_FAMILY_NAME}" ;;
+    visio) printf '%s Visio\n' "${PRODUCT_FAMILY_NAME}" ;;
     suite) printf '%s\n' "${PRODUCT_NAME}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -819,6 +820,7 @@ product_executable_name() {
     spreadsheet) printf 'EuroOfficeSpreadsheet\n' ;;
     presentation) printf 'EuroOfficePresentation\n' ;;
     pdf) printf 'EuroOfficePDF\n' ;;
+    visio) printf 'EuroOfficeVisio\n' ;;
     suite) printf '%s\n' "${PRODUCT_NAME}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -826,7 +828,7 @@ product_executable_name() {
 
 product_bundle_id() {
   case "$1" in
-    text|spreadsheet|presentation|pdf) printf '%s.%s\n' "${BUNDLE_ID}" "$1" ;;
+    text|spreadsheet|presentation|pdf|visio) printf '%s.%s\n' "${BUNDLE_ID}" "$1" ;;
     suite) printf '%s\n' "${BUNDLE_ID}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -838,6 +840,7 @@ product_url_scheme() {
     spreadsheet) printf 'euro-office-spreadsheet\n' ;;
     presentation) printf 'euro-office-presentation\n' ;;
     pdf) printf 'euro-office-pdf\n' ;;
+    visio) printf 'euro-office-visio\n' ;;
     suite) printf 'euro-office\n' ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -871,6 +874,9 @@ allowed_extensions = {
     },
     "pdf": {
         "pdf", "docxf", "oform",
+    },
+    "visio": {
+        "vsdx", "vssx", "vstx", "vsdm", "vssm", "vstm",
     },
 }
 
@@ -1018,7 +1024,8 @@ clean_macos_product_outputs() {
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Text.app" \
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Spreadsheet.app" \
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Presentation.app" \
-    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} PDF.app"
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} PDF.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Visio.app"
 }
 
 stage_macos_apps() {

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -5,13 +5,28 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${BUILD_DIR}/.." && pwd)"
 
-PRODUCT_FAMILY_NAME="${PRODUCT_FAMILY_NAME:-AUTARQ}"
-PRODUCT_NAME="${PRODUCT_NAME:-${PRODUCT_FAMILY_NAME} Office}"
-BUNDLE_ID="${PRODUCT_BUNDLE_IDENTIFIER:-com.autarq.office}"
-MACOS_PRODUCTS="${EO_MACOS_PRODUCTS:-split}"
+read_build_tools_rev() {
+  local rev_file="$1"
+  if [[ ! -f "${rev_file}" ]]; then
+    printf '[macos] error: build tools revision file not found: %s\n' "${rev_file}" >&2
+    exit 1
+  fi
+  tr -d '[:space:]' < "${rev_file}"
+}
+
+PRODUCT_FAMILY_NAME="${PRODUCT_FAMILY_NAME:-Euro-Office}"
+PRODUCT_NAME="${PRODUCT_NAME:-${PRODUCT_FAMILY_NAME}}"
+BUNDLE_ID="${PRODUCT_BUNDLE_IDENTIFIER:-org.euro-office.desktopeditors}"
+MACOS_PRODUCTS="${EO_MACOS_PRODUCTS:-suite}"
 SCHEME="${SCHEME:-ONLYOFFICE-arm}"
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
 ARCH="${1:-}"
-BUILD_TOOLS_REV="${BUILD_TOOLS_REV:-c5f6c2e02b50dfcc5c53a207f9a6cde84896de91}"
+BUILD_TOOLS_REV_FILE="${BUILD_TOOLS_REV_FILE:-${SCRIPT_DIR}/build_tools.sha}"
+BUILD_TOOLS_REV="${BUILD_TOOLS_REV:-$(read_build_tools_rev "${BUILD_TOOLS_REV_FILE}")}"
 BUILD_TOOLS_PLATFORM="${BUILD_TOOLS_PLATFORM:-mac_arm64}"
 MIN_FREE_GIB="${MIN_FREE_GIB:-150}"
 QT_DIR="${QT_DIR:-${REPO_ROOT}/_qt}"
@@ -21,9 +36,11 @@ LOG_DIR="${BUILD_DIR}/deploy/macos/logs"
 DERIVED_DATA_DIR="${BUILD_DIR}/deploy/macos/DerivedData/arm64"
 TOOLS_BIN_DIR="${BUILD_DIR}/deploy/macos/tools/bin"
 CMAKE_VENV_DIR="${BUILD_DIR}/deploy/macos/tools/cmake-venv"
+PATCH_CLEANUP_FILE="${BUILD_DIR}/deploy/macos/tools/applied-patches.$$"
 BUILD_TOOLS_DIR="${REPO_ROOT}/build_tools"
 DESKTOP_APPS_DIR="${DESKTOP_APPS_DIR:-${REPO_ROOT}/desktop-apps}"
 XCODE_PROJECT="${DESKTOP_APPS_DIR}/macos/ONLYOFFICE.xcodeproj"
+PATCH_DIR="${SCRIPT_DIR}/patches"
 
 PREFLIGHT_FAILURES=0
 EXTERNAL_DESKTOP_APPS_LINK=""
@@ -46,20 +63,45 @@ cleanup_external_desktop_apps_link() {
   fi
 }
 
-trap cleanup_external_desktop_apps_link EXIT
+cleanup_applied_patches() {
+  local record patch_root patch_file
+  if [[ ! -f "${PATCH_CLEANUP_FILE}" ]]; then
+    return
+  fi
+
+  while IFS= read -r record; do
+    [[ -z "${record}" ]] && continue
+    patch_root="${record%%|*}"
+    patch_file="${record#*|}"
+    if git -C "${patch_root}" apply --unidiff-zero --reverse --check "${patch_file}" >/dev/null 2>&1; then
+      git -C "${patch_root}" apply --unidiff-zero --reverse "${patch_file}" || true
+    fi
+  done < "${PATCH_CLEANUP_FILE}"
+  rm -f "${PATCH_CLEANUP_FILE}"
+}
+
+cleanup() {
+  cleanup_applied_patches
+  cleanup_external_desktop_apps_link
+}
+
+trap cleanup EXIT
 
 usage() {
   cat <<EOF
 Usage:
   ./macos/build.sh --check
+  ./macos/build.sh --dry-run arm64
   ./macos/build.sh arm64
 
 Environment:
   MIN_FREE_GIB=150
   EO_SKIP_SPACE_CHECK=1
   QT_DIR=/path/to/qt-root
+  BUILD_TOOLS_REV_FILE=${BUILD_TOOLS_REV_FILE}
   BUILD_TOOLS_REV=${BUILD_TOOLS_REV}
-  EO_MACOS_PRODUCTS=split|suite|text,spreadsheet,presentation,pdf,visio
+  EO_MACOS_PRODUCTS=suite
+  EO_ALLOW_GIT_HTTPS_FALLBACK=1
   CODESIGNING_IDENTITY="Developer ID Application: ..."
   DEVELOPMENT_TEAM=<team-id>
   EO_SKIP_LAUNCH=1
@@ -308,6 +350,101 @@ preflight() {
   fi
 }
 
+dry_run_existing_target() {
+  local path="$1"
+
+  if [[ -e "${path}" || -L "${path}" ]]; then
+    resolved_path "${path}"
+  else
+    printf 'absent'
+  fi
+}
+
+dry_run_sibling_link() {
+  local name="$1"
+  local target_dir="$2"
+  local parent_dir="$3"
+  local link_path="${parent_dir}/${name}"
+  local current_target
+
+  current_target="$(dry_run_existing_target "${link_path}")"
+  info "dry-run: Xcode sibling ${name}: ${link_path} -> ${target_dir} (current: ${current_target})"
+}
+
+dry_run() {
+  OUT_DIR="${BUILD_DIR}/deploy/macos/${ARCH}"
+  DERIVED_DATA_DIR="${BUILD_DIR}/deploy/macos/DerivedData/${ARCH}"
+
+  if [[ "${ARCH}" != "arm64" ]]; then
+    fail "--dry-run currently supports arm64 only"
+  fi
+
+  local products
+  products="$(selected_products | paste -sd, -)"
+
+  info "dry-run: no submodules, symlinks, patches, build outputs, or git config will be changed"
+  info "dry-run: product output: ${OUT_DIR}/${PRODUCT_NAME}.app"
+  info "dry-run: bundle identifier: ${BUNDLE_ID}"
+  info "dry-run: products: ${products}"
+  info "dry-run: build_tools revision file: ${BUILD_TOOLS_REV_FILE}"
+  info "dry-run: build_tools revision: ${BUILD_TOOLS_REV}"
+  info "dry-run: Xcode project: ${XCODE_PROJECT}"
+  info "dry-run: DerivedData: ${DERIVED_DATA_DIR}"
+  info "dry-run: compatibility patches: ${PATCH_DIR}"
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    warn "dry-run: macOS build must run on Darwin; current host is $(uname -s)"
+  fi
+
+  if [[ "$(uname -m)" != "arm64" ]]; then
+    warn "dry-run: arm64 build requested on $(uname -m); the real build will fail on this host"
+  fi
+
+  if [[ "${EO_ALLOW_GIT_HTTPS_FALLBACK:-0}" == "1" ]]; then
+    info "dry-run: would opt in to local git@github.com: -> https://github.com/ rewrite if none exists"
+  else
+    info "dry-run: would leave git@github.com: submodule URLs unchanged"
+  fi
+
+  local default_desktop_apps_dir="${REPO_ROOT}/desktop-apps"
+  local absolute_desktop_apps_dir
+  absolute_desktop_apps_dir="$(absolute_path "${DESKTOP_APPS_DIR}")"
+
+  if [[ "${absolute_desktop_apps_dir}" == "${default_desktop_apps_dir}" ]]; then
+    info "dry-run: would use desktop-apps submodule in place: ${default_desktop_apps_dir}"
+  else
+    local resolved_default resolved_external desktop_apps_parent
+    resolved_default="$(dry_run_existing_target "${default_desktop_apps_dir}")"
+    if [[ -e "${DESKTOP_APPS_DIR}" || -L "${DESKTOP_APPS_DIR}" ]]; then
+      resolved_external="$(resolved_path "${DESKTOP_APPS_DIR}")"
+    else
+      resolved_external="missing"
+    fi
+    desktop_apps_parent="$(cd "$(dirname "${DESKTOP_APPS_DIR}")" && pwd)"
+
+    info "dry-run: external desktop-apps checkout: ${DESKTOP_APPS_DIR} (resolved: ${resolved_external})"
+    info "dry-run: build_tools desktop-apps link: ${default_desktop_apps_dir} -> ${DESKTOP_APPS_DIR} (current: ${resolved_default})"
+    dry_run_sibling_link build_tools "${BUILD_TOOLS_DIR}" "${desktop_apps_parent}"
+    dry_run_sibling_link core "${REPO_ROOT}/core" "${desktop_apps_parent}"
+    dry_run_sibling_link desktop-sdk "${REPO_ROOT}/desktop-sdk" "${desktop_apps_parent}"
+    dry_run_sibling_link dictionaries "${REPO_ROOT}/dictionaries" "${desktop_apps_parent}"
+  fi
+
+  if has_versioned_qt_layout "${QT_DIR}"; then
+    info "dry-run: would use Qt layout at ${QT_DIR}"
+  else
+    local homebrew_qt
+    homebrew_qt="$(discover_homebrew_qt || true)"
+    if [[ -n "${homebrew_qt}" ]]; then
+      info "dry-run: would create build_tools Qt layout under ${QT_DIR} from ${homebrew_qt}"
+    else
+      warn "dry-run: Qt was not found; the real build needs QT_DIR or a Homebrew Qt install"
+    fi
+  fi
+
+  info "dry-run: would update submodules, checkout build_tools, apply reviewed patches, build native payload, run xcodebuild, stage ${PRODUCT_NAME}.app, verify codesign and launch"
+}
+
 ensure_arm64_host() {
   if [[ "$(uname -m)" != "arm64" ]]; then
     fail "arm64 build requested on non-arm64 host ($(uname -m)); universal/x86_64 support is not wired yet"
@@ -350,6 +487,9 @@ ensure_external_repo_sibling_for_xcode() {
     resolved_link_path="$(resolved_path "${link_path}")"
     if [[ "${resolved_link_path}" != "${resolved_target_dir}" ]]; then
       fail "${link_path} already resolves to ${resolved_link_path}, expected ${resolved_target_dir}"
+    fi
+    if [[ -L "${link_path}" ]]; then
+      info "using existing ${name} symlink: ${link_path}"
     fi
     return
   fi
@@ -399,6 +539,7 @@ ensure_external_desktop_apps_for_build_tools() {
     if [[ "${linked_target}" != "${resolved_desktop_apps_dir}" ]]; then
       fail "${default_desktop_apps_dir} already points to ${linked_target}, expected ${resolved_desktop_apps_dir}"
     fi
+    info "using existing desktop-apps symlink: ${default_desktop_apps_dir}"
     return
   fi
 
@@ -416,7 +557,14 @@ ensure_external_desktop_apps_for_build_tools() {
 
 ensure_submodules() {
   info "syncing submodules"
-  git -C "${REPO_ROOT}" config --local url.https://github.com/.insteadOf git@github.com:
+  if git -C "${REPO_ROOT}" config --local --get-regexp '^url\..*\.insteadOf$' 2>/dev/null | grep -q 'git@github.com:'; then
+    info "using existing local git URL rewrite for git@github.com:"
+  elif [[ "${EO_ALLOW_GIT_HTTPS_FALLBACK:-0}" == "1" ]]; then
+    git -C "${REPO_ROOT}" config --local url.https://github.com/.insteadOf git@github.com:
+    info "enabled opt-in HTTPS fallback for git@github.com: submodule URLs"
+  else
+    info "leaving git@github.com: submodule URLs unchanged; set EO_ALLOW_GIT_HTTPS_FALLBACK=1 to rewrite them to HTTPS"
+  fi
   git -C "${REPO_ROOT}" submodule sync --recursive
 
   local default_desktop_apps_dir="${REPO_ROOT}/desktop-apps"
@@ -501,8 +649,15 @@ exit 127
 EOF
   chmod +x "${TOOLS_BIN_DIR}/grunt"
   prepend_path_var PATH "${TOOLS_BIN_DIR}"
+
+  # build_tools sets NODE_ENV=production before npm install. npm 10 honors that
+  # by omitting dev dependencies, but the Grunt build files need local dev
+  # helpers such as time-grunt. Clear both env spellings and explicitly include
+  # dev dependencies so the behavior is stable across npm releases. The
+  # production flag keeps older npm releases on the same path.
   unset NPM_CONFIG_OMIT npm_config_omit
   export NPM_CONFIG_INCLUDE=dev
+  export NPM_CONFIG_PRODUCTION=false
 
   prepend_path_var CPATH "${katana_include}"
   prepend_path_var CPATH "${gumbo_include}"
@@ -544,30 +699,39 @@ reset_incomplete_boost_build() {
   rm -rf "${boost_build_dir}"
 }
 
-patch_boost_datetime_header() {
-  local source="$1"
+apply_reviewed_patch() {
+  local patch_root="$1"
+  local patch_file="$2"
+  local description="$3"
 
-  if [[ ! -f "${source}" ]]; then
+  if [[ ! -f "${patch_file}" ]]; then
+    fail "compatibility patch missing: ${patch_file}"
+  fi
+  if [[ ! -d "${patch_root}" ]]; then
+    fail "patch root missing for ${description}: ${patch_root}"
+  fi
+
+  if git -C "${patch_root}" apply --unidiff-zero --check "${patch_file}" >/dev/null 2>&1; then
+    git -C "${patch_root}" apply --unidiff-zero "${patch_file}"
+    mkdir -p "$(dirname "${PATCH_CLEANUP_FILE}")"
+    printf '%s|%s\n' "${patch_root}" "${patch_file}" >> "${PATCH_CLEANUP_FILE}"
+    info "applied reviewed compatibility patch: ${description}"
     return
   fi
 
-  if ! grep -q 'numeric_cast<.*_type>' "${source}"; then
+  if git -C "${patch_root}" apply --unidiff-zero --reverse --check "${patch_file}" >/dev/null 2>&1; then
+    info "reviewed compatibility patch already present: ${description}"
     return
   fi
 
-  perl -0pi -e '
-    s/numeric_cast<hour_type>\(h\)/static_cast<hour_type>(h)/g;
-    s/numeric_cast<min_type>\(m\)/static_cast<min_type>(m)/g;
-    s/numeric_cast<sec_type>\(s\)/static_cast<sec_type>(s)/g;
-  ' "${source}"
-  info "patched Boost.DateTime numeric casts for current Clang/Boost compatibility: ${source}"
+  fail "could not apply reviewed compatibility patch: ${description}"
 }
 
 prepare_boost_sources() {
   local boost_dir="${REPO_ROOT}/core/Common/3dParty/boost"
   local boost_src="${boost_dir}/boost_1_72_0"
-  local source_header="${boost_src}/libs/date_time/include/boost/date_time/posix_time/posix_time_duration.hpp"
-  local installed_header="${boost_dir}/build/${BUILD_TOOLS_PLATFORM}/include/boost/date_time/posix_time/posix_time_duration.hpp"
+  local date_time_src="${boost_src}/libs/date_time"
+  local installed_include="${boost_dir}/build/${BUILD_TOOLS_PLATFORM}/include"
 
   printf '%s' 'boost_version_5' > "${boost_dir}/boost.data"
 
@@ -577,8 +741,17 @@ prepare_boost_sources() {
       https://github.com/boostorg/boost.git boost_1_72_0 -b boost-1.72.0
   fi
 
-  patch_boost_datetime_header "${source_header}"
-  patch_boost_datetime_header "${installed_header}"
+  apply_reviewed_patch \
+    "${date_time_src}" \
+    "${PATCH_DIR}/boost-date-time-duration.patch" \
+    "Boost.DateTime source numeric casts"
+
+  if [[ -f "${installed_include}/boost/date_time/posix_time/posix_time_duration.hpp" ]]; then
+    apply_reviewed_patch \
+      "${installed_include}" \
+      "${PATCH_DIR}/boost-date-time-duration-installed.patch" \
+      "Boost.DateTime installed header numeric casts"
+  fi
 }
 
 iwork_module_version() {
@@ -587,9 +760,9 @@ iwork_module_version() {
 }
 
 patch_libetonyek_clang_compat() {
-  local table_source="${REPO_ROOT}/core/Common/3dParty/apple/libetonyek/src/lib/IWORKTable.cpp"
-  local path_source="${REPO_ROOT}/core/Common/3dParty/apple/libetonyek/src/lib/contexts/IWORKPathElement.cpp"
-  local patched=0
+  local libetonyek_dir="${REPO_ROOT}/core/Common/3dParty/apple/libetonyek"
+  local table_source="${libetonyek_dir}/src/lib/IWORKTable.cpp"
+  local path_source="${libetonyek_dir}/src/lib/contexts/IWORKPathElement.cpp"
 
   if [[ ! -f "${table_source}" ]]; then
     fail "expected libetonyek source was not fetched: ${table_source}"
@@ -599,43 +772,17 @@ patch_libetonyek_clang_compat() {
     fail "expected libetonyek source was not fetched: ${path_source}"
   fi
 
-  if grep -q 'numeric_cast<int>(' "${table_source}"; then
-    perl -0pi -e 's/numeric_cast<int>\((col|r|numRepeat|cell\.m_columnSpan|cell\.m_rowSpan)\)/static_cast<int>($1)/g' "${table_source}"
-    patched=1
-  fi
-
-  if grep -q 'numeric_cast<unsigned>(' "${path_source}"; then
-    perl -0pi -e 's/numeric_cast<unsigned>\(get\(m_point\)\.m_x\)/static_cast<unsigned>(get(m_point).m_x)/g; s/numeric_cast<unsigned>\(m_value\)/static_cast<unsigned>(m_value)/g' "${path_source}"
-    patched=1
-  fi
-
-  if [[ "${patched}" -eq 1 ]]; then
-    info "patched libetonyek numeric casts for current Clang/Boost compatibility"
-  fi
+  apply_reviewed_patch \
+    "${libetonyek_dir}" \
+    "${PATCH_DIR}/libetonyek-clang-compat.patch" \
+    "libetonyek numeric casts"
 }
 
 patch_odf_clang_compat() {
-  local sources=(
-    "${REPO_ROOT}/core/OdfFile/Reader/Converter/pptx_table_context.cpp"
-    "${REPO_ROOT}/core/OdfFile/Reader/Converter/xlsx_borders.cpp"
-  )
-  local source
-  local patched=0
-
-  for source in "${sources[@]}"; do
-    if [[ ! -f "${source}" ]]; then
-      fail "expected ODF converter source was not found: ${source}"
-    fi
-
-    if grep -q 'boost::lexical_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu))' "${source}"; then
-      perl -0pi -e 's/boost::lexical_cast<int>\(borderStyle->get_length\(\)\.get_value_unit\(odf_types::length::emu\)\)/static_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu))/g' "${source}"
-      patched=1
-    fi
-  done
-
-  if [[ "${patched}" -eq 1 ]]; then
-    info "patched ODF table border width casts for current Clang/Boost compatibility"
-  fi
+  apply_reviewed_patch \
+    "${REPO_ROOT}/core" \
+    "${PATCH_DIR}/odf-border-width-clang-compat.patch" \
+    "ODF table border width casts"
 }
 
 prepare_iwork_sources() {
@@ -787,7 +934,7 @@ ensure_draw_empty_template() {
   fi
 
   mkdir -p "${converter_dir}/empty"
-  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/autarq-vsdx.XXXXXX")"
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/euro-office-vsdx.XXXXXX")"
   printf 'VSDY;v10;0;' > "${tmp_dir}/empty.vsdt"
 
   if ! "${x2t}" "${tmp_dir}/empty.vsdt" "${template}"; then
@@ -822,17 +969,11 @@ entitlements_file() {
 
 selected_products() {
   case "${MACOS_PRODUCTS}" in
-    split)
-      printf '%s\n' text spreadsheet presentation pdf visio
-      ;;
     suite)
       printf '%s\n' suite
       ;;
-    all)
-      printf '%s\n' suite text spreadsheet presentation pdf visio
-      ;;
     *)
-      printf '%s\n' "${MACOS_PRODUCTS//,/ }" | xargs -n1
+      fail "this Euro-Office branch exports only the suite app; set EO_MACOS_PRODUCTS=suite or use the AUTARQ branding branch for split app builds"
       ;;
   esac
 }
@@ -851,11 +992,11 @@ product_app_name() {
 
 product_executable_name() {
   case "$1" in
-    text) printf 'AUTARQWrite\n' ;;
-    spreadsheet) printf 'AUTARQSheets\n' ;;
-    presentation) printf 'AUTARQKeynote\n' ;;
-    pdf) printf 'AUTARQPDF\n' ;;
-    visio) printf 'AUTARQDraw\n' ;;
+    text) printf '%sWrite\n' "${PRODUCT_FAMILY_NAME//[^[:alnum:]]/}" ;;
+    spreadsheet) printf '%sSheets\n' "${PRODUCT_FAMILY_NAME//[^[:alnum:]]/}" ;;
+    presentation) printf '%sPresentation\n' "${PRODUCT_FAMILY_NAME//[^[:alnum:]]/}" ;;
+    pdf) printf '%sPDF\n' "${PRODUCT_FAMILY_NAME//[^[:alnum:]]/}" ;;
+    visio) printf '%sDraw\n' "${PRODUCT_FAMILY_NAME//[^[:alnum:]]/}" ;;
     suite) printf '%s\n' "${PRODUCT_NAME}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -875,23 +1016,23 @@ product_bundle_id() {
 
 product_url_scheme() {
   case "$1" in
-    text) printf 'autarq-write\n' ;;
-    spreadsheet) printf 'autarq-sheets\n' ;;
-    presentation) printf 'autarq-keynote\n' ;;
-    pdf) printf 'autarq-pdf\n' ;;
-    visio) printf 'autarq-draw\n' ;;
-    suite) printf 'autarq-office\n' ;;
+    text) printf 'euro-office-write\n' ;;
+    spreadsheet) printf 'euro-office-sheets\n' ;;
+    presentation) printf 'euro-office-presentation\n' ;;
+    pdf) printf 'euro-office-pdf\n' ;;
+    visio) printf 'euro-office-draw\n' ;;
+    suite) printf 'euro-office\n' ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
 }
 
 product_icon_file() {
   case "$1" in
-    text) printf 'autarq-write\n' ;;
-    spreadsheet) printf 'autarq-sheets\n' ;;
-    presentation) printf 'autarq-keynote\n' ;;
-    pdf) printf 'autarq-pdf\n' ;;
-    visio) printf 'autarq-draw\n' ;;
+    text) printf 'euro-office-write\n' ;;
+    spreadsheet) printf 'euro-office-sheets\n' ;;
+    presentation) printf 'euro-office-presentation\n' ;;
+    pdf) printf 'euro-office-pdf\n' ;;
+    visio) printf 'euro-office-draw\n' ;;
     suite) printf '' ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -1115,6 +1256,22 @@ stage_macos_apps() {
   done < <(selected_products)
 }
 
+wait_for_app_process() {
+  local executable_path="$1"
+  local app_name="$2"
+  local attempt
+
+  for attempt in $(seq 1 30); do
+    if pgrep -f "${executable_path}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  warn "launch smoke test timed out waiting for ${app_name} after 30 seconds"
+  return 1
+}
+
 verify_app() {
   local app="$1"
   local plist="${app}/Contents/Info.plist"
@@ -1164,8 +1321,7 @@ verify_app() {
 
   info "running launch smoke test for ${app_name}"
   open -n "${app}"
-  sleep 4
-  if ! pgrep -f "${app}/Contents/MacOS/${executable_name}" >/dev/null 2>&1; then
+  if ! wait_for_app_process "${app}/Contents/MacOS/${executable_name}" "${app_name}"; then
     fail "launch smoke test did not find a running ${app_name} process"
   fi
   osascript -e "tell application id \"${bundle_id}\" to quit" >/dev/null 2>&1 || true
@@ -1196,6 +1352,10 @@ main() {
     arm64)
       OUT_DIR="${BUILD_DIR}/deploy/macos/${ARCH}"
       DERIVED_DATA_DIR="${BUILD_DIR}/deploy/macos/DerivedData/${ARCH}"
+      if [[ "${DRY_RUN}" == "1" ]]; then
+        dry_run
+        return
+      fi
       preflight
       ensure_arm64_host
       ensure_submodules

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -5,9 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${BUILD_DIR}/.." && pwd)"
 
-PRODUCT_FAMILY_NAME="${PRODUCT_FAMILY_NAME:-Euro-Office}"
-PRODUCT_NAME="${PRODUCT_NAME:-${PRODUCT_FAMILY_NAME}}"
-BUNDLE_ID="${PRODUCT_BUNDLE_IDENTIFIER:-org.euro-office.desktopeditors}"
+PRODUCT_FAMILY_NAME="${PRODUCT_FAMILY_NAME:-AUTARQ}"
+PRODUCT_NAME="${PRODUCT_NAME:-${PRODUCT_FAMILY_NAME} Office}"
+BUNDLE_ID="${PRODUCT_BUNDLE_IDENTIFIER:-com.autarq.office}"
 MACOS_PRODUCTS="${EO_MACOS_PRODUCTS:-split}"
 SCHEME="${SCHEME:-ONLYOFFICE-arm}"
 ARCH="${1:-}"
@@ -804,11 +804,11 @@ selected_products() {
 
 product_app_name() {
   case "$1" in
-    text) printf '%s Text\n' "${PRODUCT_FAMILY_NAME}" ;;
-    spreadsheet) printf '%s Spreadsheet\n' "${PRODUCT_FAMILY_NAME}" ;;
-    presentation) printf '%s Presentation\n' "${PRODUCT_FAMILY_NAME}" ;;
+    text) printf '%s Write\n' "${PRODUCT_FAMILY_NAME}" ;;
+    spreadsheet) printf '%s Sheets\n' "${PRODUCT_FAMILY_NAME}" ;;
+    presentation) printf '%s Keynote\n' "${PRODUCT_FAMILY_NAME}" ;;
     pdf) printf '%s PDF\n' "${PRODUCT_FAMILY_NAME}" ;;
-    visio) printf '%s Visio\n' "${PRODUCT_FAMILY_NAME}" ;;
+    visio) printf '%s Draw\n' "${PRODUCT_FAMILY_NAME}" ;;
     suite) printf '%s\n' "${PRODUCT_NAME}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -816,11 +816,11 @@ product_app_name() {
 
 product_executable_name() {
   case "$1" in
-    text) printf 'EuroOfficeText\n' ;;
-    spreadsheet) printf 'EuroOfficeSpreadsheet\n' ;;
-    presentation) printf 'EuroOfficePresentation\n' ;;
-    pdf) printf 'EuroOfficePDF\n' ;;
-    visio) printf 'EuroOfficeVisio\n' ;;
+    text) printf 'AUTARQWrite\n' ;;
+    spreadsheet) printf 'AUTARQSheets\n' ;;
+    presentation) printf 'AUTARQKeynote\n' ;;
+    pdf) printf 'AUTARQPDF\n' ;;
+    visio) printf 'AUTARQDraw\n' ;;
     suite) printf '%s\n' "${PRODUCT_NAME}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -828,7 +828,11 @@ product_executable_name() {
 
 product_bundle_id() {
   case "$1" in
-    text|spreadsheet|presentation|pdf|visio) printf '%s.%s\n' "${BUNDLE_ID}" "$1" ;;
+    text) printf '%s.write\n' "${BUNDLE_ID}" ;;
+    spreadsheet) printf '%s.sheets\n' "${BUNDLE_ID}" ;;
+    presentation) printf '%s.keynote\n' "${BUNDLE_ID}" ;;
+    pdf) printf '%s.pdf\n' "${BUNDLE_ID}" ;;
+    visio) printf '%s.draw\n' "${BUNDLE_ID}" ;;
     suite) printf '%s\n' "${BUNDLE_ID}" ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
@@ -836,12 +840,24 @@ product_bundle_id() {
 
 product_url_scheme() {
   case "$1" in
-    text) printf 'euro-office-text\n' ;;
-    spreadsheet) printf 'euro-office-spreadsheet\n' ;;
-    presentation) printf 'euro-office-presentation\n' ;;
-    pdf) printf 'euro-office-pdf\n' ;;
-    visio) printf 'euro-office-visio\n' ;;
-    suite) printf 'euro-office\n' ;;
+    text) printf 'autarq-write\n' ;;
+    spreadsheet) printf 'autarq-sheets\n' ;;
+    presentation) printf 'autarq-keynote\n' ;;
+    pdf) printf 'autarq-pdf\n' ;;
+    visio) printf 'autarq-draw\n' ;;
+    suite) printf 'autarq-office\n' ;;
+    *) fail "unknown macOS product component: $1" ;;
+  esac
+}
+
+product_icon_file() {
+  case "$1" in
+    text) printf 'autarq-write\n' ;;
+    spreadsheet) printf 'autarq-sheets\n' ;;
+    presentation) printf 'autarq-keynote\n' ;;
+    pdf) printf 'autarq-pdf\n' ;;
+    visio) printf 'autarq-draw\n' ;;
+    suite) printf '' ;;
     *) fail "unknown macOS product component: $1" ;;
   esac
 }
@@ -853,12 +869,13 @@ patch_product_info_plist() {
   local bundle_id="$4"
   local url_scheme="$5"
   local component="$6"
+  local icon_file="$7"
 
-  python3 - "${plist}" "${app_name}" "${executable_name}" "${bundle_id}" "${url_scheme}" "${component}" <<'PY'
+  python3 - "${plist}" "${app_name}" "${executable_name}" "${bundle_id}" "${url_scheme}" "${component}" "${icon_file}" <<'PY'
 import plistlib
 import sys
 
-plist_path, app_name, executable_name, bundle_id, url_scheme, component = sys.argv[1:7]
+plist_path, app_name, executable_name, bundle_id, url_scheme, component, icon_file = sys.argv[1:8]
 
 allowed_extensions = {
     "text": {
@@ -900,6 +917,8 @@ info["CFBundleDisplayName"] = app_name
 info["CFBundleExecutable"] = executable_name
 info["CFBundleIdentifier"] = bundle_id
 info["EOProductComponent"] = component
+if icon_file:
+    info["CFBundleIconFile"] = icon_file
 info["CFBundleURLTypes"] = [{
     "CFBundleTypeRole": "Editor",
     "CFBundleURLSchemes": [url_scheme],
@@ -977,12 +996,13 @@ build_xcode_app() {
 
 stage_product_app() {
   local component="$1"
-  local app_name executable_name bundle_id url_scheme app old_exe candidate
+  local app_name executable_name bundle_id url_scheme icon_file icon_source app old_exe candidate
 
   app_name="$(product_app_name "${component}")"
   executable_name="$(product_executable_name "${component}")"
   bundle_id="$(product_bundle_id "${component}")"
   url_scheme="$(product_url_scheme "${component}")"
+  icon_file="$(product_icon_file "${component}")"
   app="${OUT_DIR}/${app_name}.app"
 
   rm -rf "${app}"
@@ -1005,7 +1025,15 @@ stage_product_app() {
     fi
 
     mv "${old_exe}" "${app}/Contents/MacOS/${executable_name}"
-    patch_product_info_plist "${app}/Contents/Info.plist" "${app_name}" "${executable_name}" "${bundle_id}" "${url_scheme}" "${component}"
+    if [[ -n "${icon_file}" ]]; then
+      icon_source="${DESKTOP_APPS_DIR}/macos/ONLYOFFICE/Resources/ProductIcons/${icon_file}.icns"
+      if [[ ! -f "${icon_source}" ]]; then
+        fail "product icon missing: ${icon_source}"
+      fi
+      cp "${icon_source}" "${app}/Contents/Resources/${icon_file}.icns"
+    fi
+
+    patch_product_info_plist "${app}/Contents/Info.plist" "${app_name}" "${executable_name}" "${bundle_id}" "${url_scheme}" "${component}" "${icon_file}"
     resign_app "${app}"
   fi
 
@@ -1023,9 +1051,17 @@ clean_macos_product_outputs() {
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME}.app" \
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Text.app" \
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Spreadsheet.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Sheets.app" \
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Presentation.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Keynote.app" \
     "${OUT_DIR}/${PRODUCT_FAMILY_NAME} PDF.app" \
-    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Visio.app"
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Visio.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Draw.app" \
+    "${OUT_DIR}/Euro-Office Text.app" \
+    "${OUT_DIR}/Euro-Office Spreadsheet.app" \
+    "${OUT_DIR}/Euro-Office Presentation.app" \
+    "${OUT_DIR}/Euro-Office PDF.app" \
+    "${OUT_DIR}/Euro-Office Visio.app"
 }
 
 stage_macos_apps() {
@@ -1046,7 +1082,7 @@ stage_macos_apps() {
 verify_app() {
   local app="$1"
   local plist="${app}/Contents/Info.plist"
-  local app_name executable_name bundle_id exe log_name
+  local app_name executable_name bundle_id icon_file exe log_name
 
   if [[ ! -d "${app}" ]]; then
     fail "app bundle missing: ${app}"
@@ -1055,8 +1091,13 @@ verify_app() {
   app_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "${plist}")"
   executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "${plist}")"
   bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${plist}")"
+  icon_file="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "${plist}" 2>/dev/null || true)"
   exe="${app}/Contents/MacOS/${executable_name}"
   log_name="${app_name// /-}"
+
+  if [[ -n "${icon_file}" && ! -f "${app}/Contents/Resources/${icon_file}.icns" ]]; then
+    fail "app icon missing for ${app_name}: ${icon_file}.icns"
+  fi
 
   if [[ ! -x "${exe}" ]]; then
     local candidate

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -954,6 +954,7 @@ info["CFBundleIdentifier"] = bundle_id
 info["EOProductComponent"] = component
 if icon_file:
     info["CFBundleIconFile"] = icon_file
+    info.pop("CFBundleIconName", None)
 info["CFBundleURLTypes"] = [{
     "CFBundleTypeRole": "Editor",
     "CFBundleURLSchemes": [url_scheme],

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -1007,11 +1007,26 @@ stage_product_app() {
   info "app exported to ${app}"
 }
 
+clean_macos_product_outputs() {
+  if [[ -z "${OUT_DIR}" || "${OUT_DIR}" != "${BUILD_DIR}/deploy/macos/"* ]]; then
+    fail "refusing to clean unexpected macOS output directory: ${OUT_DIR}"
+  fi
+
+  rm -rf \
+    "${OUT_DIR}/${PRODUCT_NAME}.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME}.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Text.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Spreadsheet.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} Presentation.app" \
+    "${OUT_DIR}/${PRODUCT_FAMILY_NAME} PDF.app"
+}
+
 stage_macos_apps() {
   if [[ -z "${BUILT_XCODE_APP}" || ! -d "${BUILT_XCODE_APP}" ]]; then
     fail "base Xcode app was not staged"
   fi
 
+  clean_macos_product_outputs
   STAGED_APPS=()
 
   local component

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -17,11 +17,32 @@ QT_DIR="${QT_DIR:-${REPO_ROOT}/_qt}"
 OUT_DIR="${BUILD_DIR}/deploy/macos/arm64"
 LOG_DIR="${BUILD_DIR}/deploy/macos/logs"
 DERIVED_DATA_DIR="${BUILD_DIR}/deploy/macos/DerivedData/arm64"
+TOOLS_BIN_DIR="${BUILD_DIR}/deploy/macos/tools/bin"
+CMAKE_VENV_DIR="${BUILD_DIR}/deploy/macos/tools/cmake-venv"
 BUILD_TOOLS_DIR="${REPO_ROOT}/build_tools"
 DESKTOP_APPS_DIR="${DESKTOP_APPS_DIR:-${REPO_ROOT}/desktop-apps}"
 XCODE_PROJECT="${DESKTOP_APPS_DIR}/macos/ONLYOFFICE.xcodeproj"
 
 PREFLIGHT_FAILURES=0
+EXTERNAL_DESKTOP_APPS_LINK=""
+EXTERNAL_REPO_SIBLING_LINKS=()
+
+cleanup_external_desktop_apps_link() {
+  if [[ -n "${EXTERNAL_DESKTOP_APPS_LINK}" && -L "${EXTERNAL_DESKTOP_APPS_LINK}" ]]; then
+    rm "${EXTERNAL_DESKTOP_APPS_LINK}"
+    mkdir -p "${EXTERNAL_DESKTOP_APPS_LINK}"
+  fi
+  local link_path
+  if [[ "${#EXTERNAL_REPO_SIBLING_LINKS[@]}" -gt 0 ]]; then
+    for link_path in "${EXTERNAL_REPO_SIBLING_LINKS[@]}"; do
+      if [[ -L "${link_path}" ]]; then
+        rm "${link_path}"
+      fi
+    done
+  fi
+}
+
+trap cleanup_external_desktop_apps_link EXIT
 
 usage() {
   cat <<EOF
@@ -32,7 +53,7 @@ Usage:
 Environment:
   MIN_FREE_GIB=150
   EO_SKIP_SPACE_CHECK=1
-  QT_DIR=/path/to/qt-layout
+  QT_DIR=/path/to/qt-root
   BUILD_TOOLS_REV=${BUILD_TOOLS_REV}
   CODESIGNING_IDENTITY="Developer ID Application: ..."
   DEVELOPMENT_TEAM=<team-id>
@@ -68,6 +89,30 @@ check_optional_cmd() {
   else
     warn "missing optional command: ${cmd}"
   fi
+}
+
+cmake_version() {
+  "$1" --version 2>/dev/null | awk 'NR == 1 { print $3 }'
+}
+
+cmake_is_compatible_version() {
+  local version="$1"
+  local major minor
+
+  IFS=. read -r major minor _ <<< "${version}"
+  if [[ ! "${major}" =~ ^[0-9]+$ || ! "${minor}" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+
+  if (( major != 3 )); then
+    return 1
+  fi
+
+  (( minor >= 21 ))
+}
+
+python_venv_available() {
+  python3 -m venv --help >/dev/null 2>&1
 }
 
 free_gib() {
@@ -106,6 +151,35 @@ check_xcode() {
   }
 }
 
+check_cmake() {
+  local needs_local_cmake=0
+
+  if command -v cmake >/dev/null 2>&1; then
+    local cmake_path cmake_found_version
+    cmake_path="$(command -v cmake)"
+    cmake_found_version="$(cmake_version "${cmake_path}")"
+    if cmake_is_compatible_version "${cmake_found_version}"; then
+      info "CMake ${cmake_found_version} found: ${cmake_path}"
+      return
+    fi
+
+    warn "CMake ${cmake_found_version:-unknown} found at ${cmake_path}; build_tools HEIF requires CMake >= 3.21 and < 4"
+    needs_local_cmake=1
+  else
+    warn "CMake was not found; build.sh will create a local CMake >= 3.21 and < 4"
+    needs_local_cmake=1
+  fi
+
+  if [[ "${needs_local_cmake}" == "1" ]]; then
+    if python_venv_available; then
+      info "build.sh will create a local CMake venv under ${CMAKE_VENV_DIR}"
+    else
+      warn "python3 venv support is required to create a local compatible CMake"
+      PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+    fi
+  fi
+}
+
 discover_homebrew_qt() {
   local prefix=""
 
@@ -128,26 +202,54 @@ discover_homebrew_qt() {
   fi
 }
 
-check_qt() {
-  if [[ -x "${QT_DIR}/macos/bin/qmake" ]]; then
-    info "Qt layout found: ${QT_DIR}/macos"
-    return
+qt_dir_name_has_version() {
+  local dir_name
+  dir_name="$(basename "$1")"
+  [[ "${dir_name}" =~ [0-9]+\.[0-9]+ ]]
+}
+
+qt_prefix_version() {
+  local prefix="$1"
+  local version
+  version="$("${prefix}/bin/qmake" -query QT_VERSION 2>/dev/null | sed 's/^QT_VERSION://')"
+  if [[ -z "${version}" ]]; then
+    fail "could not determine Qt version from ${prefix}/bin/qmake"
+  fi
+  printf '%s\n' "${version}"
+}
+
+has_versioned_qt_layout() {
+  local layout_root="$1"
+
+  if [[ ! -x "${layout_root}/macos/bin/qmake" && ! -x "${layout_root}/clang_64/bin/qmake" ]]; then
+    return 1
   fi
 
-  if [[ -x "${QT_DIR}/clang_64/bin/qmake" ]]; then
-    info "Qt layout found: ${QT_DIR}/clang_64"
+  if qt_dir_name_has_version "${layout_root}"; then
+    return 0
+  fi
+
+  warn "ignoring Qt layout without versioned parent: ${layout_root}"
+  return 1
+}
+
+check_qt() {
+  if has_versioned_qt_layout "${QT_DIR}"; then
+    info "Qt layout found: ${QT_DIR}"
     return
   fi
 
   local homebrew_qt
   homebrew_qt="$(discover_homebrew_qt || true)"
   if [[ -n "${homebrew_qt}" ]]; then
+    local qt_version
+    qt_version="$(qt_prefix_version "${homebrew_qt}")"
     info "Qt found via Homebrew/qmake: ${homebrew_qt}"
-    info "build.sh will create a local Qt layout under ${QT_DIR}/macos during the build"
+    info "build.sh will create a local Qt layout under ${QT_DIR}/${qt_version}/macos during the build"
     return
   fi
 
-  warn "Qt was not found. Set QT_DIR to a layout containing macos/bin/qmake or clang_64/bin/qmake."
+  warn "Qt was not found. Set QT_DIR to a build_tools layout root containing <version>/macos/bin/qmake or <version>/clang_64/bin/qmake."
   PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
 }
 
@@ -192,6 +294,7 @@ preflight() {
 
   check_disk_space
   check_xcode
+  check_cmake
   check_qt
   check_signing
 
@@ -206,10 +309,127 @@ ensure_arm64_host() {
   fi
 }
 
+is_empty_dir() {
+  local dir="$1"
+  [[ -d "${dir}" ]] && [[ -z "$(find "${dir}" -mindepth 1 -maxdepth 1 -print -quit)" ]]
+}
+
+resolved_path() {
+  local path="$1"
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "${path}"
+    return
+  fi
+
+  python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${path}"
+}
+
+absolute_path() {
+  local path="$1"
+  printf '%s/%s\n' "$(cd "$(dirname "${path}")" && pwd)" "$(basename "${path}")"
+}
+
+ensure_external_repo_sibling_for_xcode() {
+  local name="$1"
+  local target_dir="$2"
+  local desktop_apps_parent
+  local link_path
+  local resolved_target_dir
+
+  desktop_apps_parent="$(cd "${DESKTOP_APPS_DIR}/.." && pwd)"
+  link_path="${desktop_apps_parent}/${name}"
+  resolved_target_dir="$(resolved_path "${target_dir}")"
+
+  if [[ -e "${link_path}" || -L "${link_path}" ]]; then
+    local resolved_link_path
+    resolved_link_path="$(resolved_path "${link_path}")"
+    if [[ "${resolved_link_path}" != "${resolved_target_dir}" ]]; then
+      fail "${link_path} already resolves to ${resolved_link_path}, expected ${resolved_target_dir}"
+    fi
+    return
+  fi
+
+  if [[ ! -d "${target_dir}" ]]; then
+    fail "${target_dir} does not exist; cannot link ${name} for Xcode relative paths"
+  fi
+
+  ln -s "${target_dir}" "${link_path}"
+  EXTERNAL_REPO_SIBLING_LINKS+=("${link_path}")
+  info "linked ${name} into ${link_path} for Xcode relative paths"
+}
+
+ensure_external_repo_siblings_for_xcode() {
+  local default_desktop_apps_dir="${REPO_ROOT}/desktop-apps"
+  local absolute_desktop_apps_dir
+  absolute_desktop_apps_dir="$(absolute_path "${DESKTOP_APPS_DIR}")"
+
+  if [[ "${absolute_desktop_apps_dir}" == "${default_desktop_apps_dir}" ]]; then
+    return
+  fi
+
+  ensure_external_repo_sibling_for_xcode build_tools "${BUILD_TOOLS_DIR}"
+  ensure_external_repo_sibling_for_xcode core "${REPO_ROOT}/core"
+  ensure_external_repo_sibling_for_xcode desktop-sdk "${REPO_ROOT}/desktop-sdk"
+  ensure_external_repo_sibling_for_xcode dictionaries "${REPO_ROOT}/dictionaries"
+}
+
+ensure_external_desktop_apps_for_build_tools() {
+  local default_desktop_apps_dir="${REPO_ROOT}/desktop-apps"
+  local absolute_desktop_apps_dir
+  local resolved_desktop_apps_dir
+  absolute_desktop_apps_dir="$(absolute_path "${DESKTOP_APPS_DIR}")"
+  resolved_desktop_apps_dir="$(resolved_path "${DESKTOP_APPS_DIR}")"
+
+  if [[ "${absolute_desktop_apps_dir}" == "${default_desktop_apps_dir}" ]]; then
+    return
+  fi
+
+  if [[ ! -d "${DESKTOP_APPS_DIR}" ]]; then
+    fail "external desktop-apps checkout not found: ${DESKTOP_APPS_DIR}"
+  fi
+
+  if [[ -L "${default_desktop_apps_dir}" ]]; then
+    local linked_target
+    linked_target="$(resolved_path "${default_desktop_apps_dir}")"
+    if [[ "${linked_target}" != "${resolved_desktop_apps_dir}" ]]; then
+      fail "${default_desktop_apps_dir} already points to ${linked_target}, expected ${resolved_desktop_apps_dir}"
+    fi
+    return
+  fi
+
+  if [[ -e "${default_desktop_apps_dir}" ]]; then
+    if ! is_empty_dir "${default_desktop_apps_dir}"; then
+      fail "${default_desktop_apps_dir} exists and is not empty; cannot link external desktop-apps checkout"
+    fi
+    rmdir "${default_desktop_apps_dir}"
+  fi
+
+  ln -s "${DESKTOP_APPS_DIR}" "${default_desktop_apps_dir}"
+  EXTERNAL_DESKTOP_APPS_LINK="${default_desktop_apps_dir}"
+  info "linked external desktop-apps checkout into ${default_desktop_apps_dir} for build_tools"
+}
+
 ensure_submodules() {
   info "syncing submodules"
   git -C "${REPO_ROOT}" config --local url.https://github.com/.insteadOf git@github.com:
   git -C "${REPO_ROOT}" submodule sync --recursive
+
+  local default_desktop_apps_dir="${REPO_ROOT}/desktop-apps"
+  if [[ "$(resolved_path "${DESKTOP_APPS_DIR}")" != "${default_desktop_apps_dir}" ]]; then
+    info "using external desktop-apps checkout: ${DESKTOP_APPS_DIR}"
+    git -C "${REPO_ROOT}" submodule update --init --recursive \
+      core \
+      core-fonts \
+      desktop-sdk \
+      dictionaries \
+      document-templates \
+      sdkjs \
+      sdkjs-forms \
+      web-apps
+    ensure_external_desktop_apps_for_build_tools
+    return
+  fi
+
   git -C "${REPO_ROOT}" submodule update --init --recursive
 }
 
@@ -224,9 +444,262 @@ ensure_build_tools() {
   git -C "${BUILD_TOOLS_DIR}" checkout "${BUILD_TOOLS_REV}"
 }
 
+ensure_python_shim() {
+  if command -v python >/dev/null 2>&1; then
+    return
+  fi
+
+  mkdir -p "${TOOLS_BIN_DIR}"
+  ln -sf "$(command -v python3)" "${TOOLS_BIN_DIR}/python"
+  export PATH="${TOOLS_BIN_DIR}:${PATH}"
+  info "using local python shim: ${TOOLS_BIN_DIR}/python -> $(command -v python3)"
+}
+
+prepend_path_var() {
+  local name="$1"
+  local value="$2"
+  local current="${!name:-}"
+
+  case ":${current}:" in
+    *":${value}:"*) ;;
+    *)
+      if [[ -n "${current}" ]]; then
+        export "${name}=${value}:${current}"
+      else
+        export "${name}=${value}"
+      fi
+      ;;
+  esac
+}
+
+prepare_build_environment() {
+  local katana_include="${REPO_ROOT}/core/Common/3dParty/html/katana-parser/src"
+  local gumbo_include="${REPO_ROOT}/core/Common/3dParty/html/gumbo-parser/src"
+  local hyphen_include="${REPO_ROOT}/core/Common/3dParty/hyphen"
+  local hunspell_include="${REPO_ROOT}/core/Common/3dParty/hunspell/hunspell/src"
+
+  mkdir -p "${TOOLS_BIN_DIR}"
+  cat > "${TOOLS_BIN_DIR}/grunt" <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+dir="${PWD}"
+while [[ "${dir}" != "/" ]]; do
+  if [[ -x "${dir}/node_modules/.bin/grunt" ]]; then
+    exec "${dir}/node_modules/.bin/grunt" "$@"
+  fi
+  dir="$(dirname "${dir}")"
+done
+
+echo "grunt shim: node_modules/.bin/grunt not found from ${PWD}" >&2
+exit 127
+EOF
+  chmod +x "${TOOLS_BIN_DIR}/grunt"
+  prepend_path_var PATH "${TOOLS_BIN_DIR}"
+  unset NPM_CONFIG_OMIT npm_config_omit
+  export NPM_CONFIG_INCLUDE=dev
+
+  prepend_path_var CPATH "${katana_include}"
+  prepend_path_var CPATH "${gumbo_include}"
+  prepend_path_var CPATH "${hyphen_include}"
+  prepend_path_var CPATH "${hunspell_include}"
+  info "using local Node tool shim: ${TOOLS_BIN_DIR}/grunt"
+  info "configuring npm to include dev dependencies required by Grunt build files"
+  info "using qmake compatibility include paths: ${katana_include}, ${gumbo_include}, ${hyphen_include}, ${hunspell_include}"
+}
+
+reset_incomplete_boost_build() {
+  local boost_build_dir="${REPO_ROOT}/core/Common/3dParty/boost/build/${BUILD_TOOLS_PLATFORM}"
+  local boost_lib_dir="${boost_build_dir}/lib"
+
+  if [[ ! -d "${boost_build_dir}" ]]; then
+    return
+  fi
+
+  local required_libs=(
+    libboost_system.a
+    libboost_filesystem.a
+    libboost_date_time.a
+    libboost_regex.a
+  )
+  local missing=()
+  local lib
+
+  for lib in "${required_libs[@]}"; do
+    if [[ ! -f "${boost_lib_dir}/${lib}" ]]; then
+      missing+=("${lib}")
+    fi
+  done
+
+  if [[ "${#missing[@]}" -eq 0 ]]; then
+    return
+  fi
+
+  warn "removing incomplete Boost ${BUILD_TOOLS_PLATFORM} build; missing ${missing[*]}"
+  rm -rf "${boost_build_dir}"
+}
+
+patch_boost_datetime_header() {
+  local source="$1"
+
+  if [[ ! -f "${source}" ]]; then
+    return
+  fi
+
+  if ! grep -q 'numeric_cast<.*_type>' "${source}"; then
+    return
+  fi
+
+  perl -0pi -e '
+    s/numeric_cast<hour_type>\(h\)/static_cast<hour_type>(h)/g;
+    s/numeric_cast<min_type>\(m\)/static_cast<min_type>(m)/g;
+    s/numeric_cast<sec_type>\(s\)/static_cast<sec_type>(s)/g;
+  ' "${source}"
+  info "patched Boost.DateTime numeric casts for current Clang/Boost compatibility: ${source}"
+}
+
+prepare_boost_sources() {
+  local boost_dir="${REPO_ROOT}/core/Common/3dParty/boost"
+  local boost_src="${boost_dir}/boost_1_72_0"
+  local source_header="${boost_src}/libs/date_time/include/boost/date_time/posix_time/posix_time_duration.hpp"
+  local installed_header="${boost_dir}/build/${BUILD_TOOLS_PLATFORM}/include/boost/date_time/posix_time/posix_time_duration.hpp"
+
+  printf '%s' 'boost_version_5' > "${boost_dir}/boost.data"
+
+  if [[ ! -d "${boost_src}" ]]; then
+    info "fetching Boost 1.72 source checkout for macOS compatibility patches"
+    git -C "${boost_dir}" clone --recursive --depth=1 \
+      https://github.com/boostorg/boost.git boost_1_72_0 -b boost-1.72.0
+  fi
+
+  patch_boost_datetime_header "${source_header}"
+  patch_boost_datetime_header "${installed_header}"
+}
+
+iwork_module_version() {
+  awk -F\" '/check_module_version/ { print $2; exit }' \
+    "${BUILD_TOOLS_DIR}/scripts/core_common/modules/iwork.py"
+}
+
+patch_libetonyek_clang_compat() {
+  local table_source="${REPO_ROOT}/core/Common/3dParty/apple/libetonyek/src/lib/IWORKTable.cpp"
+  local path_source="${REPO_ROOT}/core/Common/3dParty/apple/libetonyek/src/lib/contexts/IWORKPathElement.cpp"
+  local patched=0
+
+  if [[ ! -f "${table_source}" ]]; then
+    fail "expected libetonyek source was not fetched: ${table_source}"
+  fi
+
+  if [[ ! -f "${path_source}" ]]; then
+    fail "expected libetonyek source was not fetched: ${path_source}"
+  fi
+
+  if grep -q 'numeric_cast<int>(' "${table_source}"; then
+    perl -0pi -e 's/numeric_cast<int>\((col|r|numRepeat|cell\.m_columnSpan|cell\.m_rowSpan)\)/static_cast<int>($1)/g' "${table_source}"
+    patched=1
+  fi
+
+  if grep -q 'numeric_cast<unsigned>(' "${path_source}"; then
+    perl -0pi -e 's/numeric_cast<unsigned>\(get\(m_point\)\.m_x\)/static_cast<unsigned>(get(m_point).m_x)/g; s/numeric_cast<unsigned>\(m_value\)/static_cast<unsigned>(m_value)/g' "${path_source}"
+    patched=1
+  fi
+
+  if [[ "${patched}" -eq 1 ]]; then
+    info "patched libetonyek numeric casts for current Clang/Boost compatibility"
+  fi
+}
+
+patch_odf_clang_compat() {
+  local sources=(
+    "${REPO_ROOT}/core/OdfFile/Reader/Converter/pptx_table_context.cpp"
+    "${REPO_ROOT}/core/OdfFile/Reader/Converter/xlsx_borders.cpp"
+  )
+  local source
+  local patched=0
+
+  for source in "${sources[@]}"; do
+    if [[ ! -f "${source}" ]]; then
+      fail "expected ODF converter source was not found: ${source}"
+    fi
+
+    if grep -q 'boost::lexical_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu))' "${source}"; then
+      perl -0pi -e 's/boost::lexical_cast<int>\(borderStyle->get_length\(\)\.get_value_unit\(odf_types::length::emu\)\)/static_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu))/g' "${source}"
+      patched=1
+    fi
+  done
+
+  if [[ "${patched}" -eq 1 ]]; then
+    info "patched ODF table border width casts for current Clang/Boost compatibility"
+  fi
+}
+
+prepare_iwork_sources() {
+  local apple_dir="${REPO_ROOT}/core/Common/3dParty/apple"
+  local version
+
+  info "preparing iwork sources for macOS"
+  (
+    cd "${apple_dir}"
+    python fetch.py
+  )
+
+  version="$(iwork_module_version)"
+  if [[ -z "${version}" ]]; then
+    fail "could not determine build_tools iwork module version"
+  fi
+  printf '%s' "${version}" > "${apple_dir}/module.version"
+
+  patch_libetonyek_clang_compat
+}
+
+ensure_compatible_cmake() {
+  local cmake_path cmake_found_version
+
+  if command -v cmake >/dev/null 2>&1; then
+    cmake_path="$(command -v cmake)"
+    cmake_found_version="$(cmake_version "${cmake_path}")"
+    if cmake_is_compatible_version "${cmake_found_version}"; then
+      info "using CMake ${cmake_found_version}: ${cmake_path}"
+      return
+    fi
+  fi
+
+  if [[ -x "${CMAKE_VENV_DIR}/bin/cmake" ]]; then
+    cmake_found_version="$(cmake_version "${CMAKE_VENV_DIR}/bin/cmake")"
+    if ! cmake_is_compatible_version "${cmake_found_version}"; then
+      rm -rf "${CMAKE_VENV_DIR}"
+    fi
+  fi
+
+  if [[ ! -x "${CMAKE_VENV_DIR}/bin/cmake" ]]; then
+    info "creating local CMake >= 3.21 and < 4 under ${CMAKE_VENV_DIR}"
+    python_venv_available || fail "python3 venv support is required to create a local compatible CMake"
+    python3 -m venv "${CMAKE_VENV_DIR}"
+    "${CMAKE_VENV_DIR}/bin/python" -m pip install --upgrade pip
+    "${CMAKE_VENV_DIR}/bin/python" -m pip install 'cmake>=3.21,<4'
+  fi
+
+  export PATH="${CMAKE_VENV_DIR}/bin:${PATH}"
+  cmake_path="$(command -v cmake)"
+  cmake_found_version="$(cmake_version "${cmake_path}")"
+  if ! cmake_is_compatible_version "${cmake_found_version}"; then
+    fail "compatible CMake was not found after setup; got ${cmake_found_version:-unknown} at ${cmake_path}"
+  fi
+
+  info "using local CMake ${cmake_found_version}: ${cmake_path}"
+}
+
 copy_qt_layout_from_prefix() {
   local prefix="$1"
-  local target="${QT_DIR}/macos"
+  local qt_version
+  qt_version="$(qt_prefix_version "${prefix}")"
+  local layout_root="${QT_DIR}"
+
+  if ! qt_dir_name_has_version "${layout_root}"; then
+    layout_root="${QT_DIR}/${qt_version}"
+  fi
+
+  local target="${layout_root}/macos"
 
   info "creating local Qt layout at ${target} from ${prefix}"
   rm -rf "${target}"
@@ -241,10 +714,12 @@ copy_qt_layout_from_prefix() {
       ln -s "${item}" "${target}/${name}"
     fi
   done
+
+  QT_DIR="${layout_root}"
 }
 
 ensure_qt_layout() {
-  if [[ -x "${QT_DIR}/macos/bin/qmake" || -x "${QT_DIR}/clang_64/bin/qmake" ]]; then
+  if has_versioned_qt_layout "${QT_DIR}"; then
     info "using Qt layout at ${QT_DIR}"
     return
   fi
@@ -252,7 +727,7 @@ ensure_qt_layout() {
   local homebrew_qt
   homebrew_qt="$(discover_homebrew_qt || true)"
   if [[ -z "${homebrew_qt}" ]]; then
-    fail "Qt was not found. Install Qt or set QT_DIR to a layout containing macos/bin/qmake or clang_64/bin/qmake."
+    fail "Qt was not found. Install Qt or set QT_DIR to a build_tools layout root containing <version>/macos/bin/qmake or <version>/clang_64/bin/qmake."
   fi
 
   copy_qt_layout_from_prefix "${homebrew_qt}"
@@ -261,6 +736,11 @@ ensure_qt_layout() {
 build_native_payload() {
   mkdir -p "${LOG_DIR}"
   info "building native desktop payload via build_tools (${BUILD_TOOLS_PLATFORM})"
+  ensure_compatible_cmake
+  ensure_python_shim
+  prepare_build_environment
+  reset_incomplete_boost_build
+  prepare_boost_sources
 
   (
     cd "${BUILD_TOOLS_DIR}"
@@ -271,6 +751,8 @@ build_native_payload() {
       --qt-dir="${QT_DIR}" \
       --clean=1 \
       --git-protocol=https
+    prepare_iwork_sources
+    patch_odf_clang_compat
     python3 make.py
   ) 2>&1 | tee "${LOG_DIR}/build-tools-${BUILD_TOOLS_PLATFORM}.log"
 
@@ -390,6 +872,7 @@ main() {
       ensure_arm64_host
       ensure_submodules
       ensure_build_tools
+      ensure_external_repo_siblings_for_xcode
       ensure_qt_layout
       build_native_payload
       build_xcode_app

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -766,7 +766,42 @@ build_native_payload() {
     fail "expected desktop payload was not produced: ${payload_dir}"
   fi
 
+  ensure_draw_empty_template "${payload_dir}"
+
   info "native payload ready: ${payload_dir}"
+}
+
+ensure_draw_empty_template() {
+  local payload_dir="$1"
+  local converter_dir="${payload_dir}/converter"
+  local template="${converter_dir}/empty/new.vsdx"
+  local x2t="${converter_dir}/x2t"
+  local tmp_dir
+
+  if [[ -f "${template}" ]]; then
+    return
+  fi
+
+  if [[ ! -x "${x2t}" ]]; then
+    fail "x2t converter missing; cannot generate Draw empty template: ${x2t}"
+  fi
+
+  mkdir -p "${converter_dir}/empty"
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/autarq-vsdx.XXXXXX")"
+  printf 'VSDY;v10;0;' > "${tmp_dir}/empty.vsdt"
+
+  if ! "${x2t}" "${tmp_dir}/empty.vsdt" "${template}"; then
+    rm -rf "${tmp_dir}"
+    fail "failed to generate Draw empty template: ${template}"
+  fi
+
+  rm -rf "${tmp_dir}"
+
+  if [[ ! -f "${template}" ]]; then
+    fail "Draw empty template was not produced: ${template}"
+  fi
+
+  info "generated Draw empty template: ${template}"
 }
 
 codesign_identity() {

--- a/build/macos/build.sh
+++ b/build/macos/build.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${BUILD_DIR}/.." && pwd)"
+
+PRODUCT_NAME="${PRODUCT_NAME:-Euro-Office}"
+BUNDLE_ID="${PRODUCT_BUNDLE_IDENTIFIER:-org.euro-office.desktopeditors}"
+SCHEME="${SCHEME:-ONLYOFFICE-arm}"
+ARCH="${1:-}"
+BUILD_TOOLS_REV="${BUILD_TOOLS_REV:-c5f6c2e02b50dfcc5c53a207f9a6cde84896de91}"
+BUILD_TOOLS_PLATFORM="${BUILD_TOOLS_PLATFORM:-mac_arm64}"
+MIN_FREE_GIB="${MIN_FREE_GIB:-150}"
+QT_DIR="${QT_DIR:-${REPO_ROOT}/_qt}"
+
+OUT_DIR="${BUILD_DIR}/deploy/macos/arm64"
+LOG_DIR="${BUILD_DIR}/deploy/macos/logs"
+DERIVED_DATA_DIR="${BUILD_DIR}/deploy/macos/DerivedData/arm64"
+BUILD_TOOLS_DIR="${REPO_ROOT}/build_tools"
+DESKTOP_APPS_DIR="${DESKTOP_APPS_DIR:-${REPO_ROOT}/desktop-apps}"
+XCODE_PROJECT="${DESKTOP_APPS_DIR}/macos/ONLYOFFICE.xcodeproj"
+
+PREFLIGHT_FAILURES=0
+
+usage() {
+  cat <<EOF
+Usage:
+  ./macos/build.sh --check
+  ./macos/build.sh arm64
+
+Environment:
+  MIN_FREE_GIB=150
+  EO_SKIP_SPACE_CHECK=1
+  QT_DIR=/path/to/qt-layout
+  BUILD_TOOLS_REV=${BUILD_TOOLS_REV}
+  CODESIGNING_IDENTITY="Developer ID Application: ..."
+  DEVELOPMENT_TEAM=<team-id>
+  EO_SKIP_LAUNCH=1
+EOF
+}
+
+info() {
+  printf '[macos] %s\n' "$*"
+}
+
+warn() {
+  printf '[macos] warning: %s\n' "$*" >&2
+}
+
+fail() {
+  printf '[macos] error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    warn "missing required command: ${cmd}"
+    PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+  fi
+}
+
+check_optional_cmd() {
+  local cmd="$1"
+  if command -v "${cmd}" >/dev/null 2>&1; then
+    info "found optional command: ${cmd}"
+  else
+    warn "missing optional command: ${cmd}"
+  fi
+}
+
+free_gib() {
+  df -Pk "${REPO_ROOT}" | awk 'NR == 2 { print int($4 / 1024 / 1024) }'
+}
+
+check_disk_space() {
+  if [[ "${EO_SKIP_SPACE_CHECK:-0}" == "1" ]]; then
+    warn "skipping disk-space check because EO_SKIP_SPACE_CHECK=1"
+    return
+  fi
+
+  local available
+  available="$(free_gib)"
+  if [[ "${available}" -lt "${MIN_FREE_GIB}" ]]; then
+    warn "only ${available}GiB free under ${REPO_ROOT}; macOS builds usually need at least ${MIN_FREE_GIB}GiB"
+    PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+  else
+    info "free disk space: ${available}GiB"
+  fi
+}
+
+check_xcode() {
+  local developer_dir
+  developer_dir="$(xcode-select -p 2>/dev/null || true)"
+  if [[ -z "${developer_dir}" ]]; then
+    warn "xcode-select is not configured"
+    PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+    return
+  fi
+
+  info "Xcode developer dir: ${developer_dir}"
+  xcodebuild -version 2>/dev/null | sed 's/^/[macos] /' || {
+    warn "xcodebuild is installed but not usable"
+    PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+  }
+}
+
+discover_homebrew_qt() {
+  local prefix=""
+
+  if command -v brew >/dev/null 2>&1; then
+    prefix="$(brew --prefix qt@5 2>/dev/null || true)"
+    if [[ -z "${prefix}" ]]; then
+      prefix="$(brew --prefix qt@6 2>/dev/null || true)"
+    fi
+    if [[ -z "${prefix}" ]]; then
+      prefix="$(brew --prefix qt 2>/dev/null || true)"
+    fi
+  fi
+
+  if [[ -z "${prefix}" ]] && command -v qmake >/dev/null 2>&1; then
+    prefix="$(cd "$(dirname "$(command -v qmake)")/.." && pwd)"
+  fi
+
+  if [[ -n "${prefix}" && -x "${prefix}/bin/qmake" ]]; then
+    printf '%s\n' "${prefix}"
+  fi
+}
+
+check_qt() {
+  if [[ -x "${QT_DIR}/macos/bin/qmake" ]]; then
+    info "Qt layout found: ${QT_DIR}/macos"
+    return
+  fi
+
+  if [[ -x "${QT_DIR}/clang_64/bin/qmake" ]]; then
+    info "Qt layout found: ${QT_DIR}/clang_64"
+    return
+  fi
+
+  local homebrew_qt
+  homebrew_qt="$(discover_homebrew_qt || true)"
+  if [[ -n "${homebrew_qt}" ]]; then
+    info "Qt found via Homebrew/qmake: ${homebrew_qt}"
+    info "build.sh will create a local Qt layout under ${QT_DIR}/macos during the build"
+    return
+  fi
+
+  warn "Qt was not found. Set QT_DIR to a layout containing macos/bin/qmake or clang_64/bin/qmake."
+  PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+}
+
+check_signing() {
+  local identities
+  identities="$(security find-identity -v -p codesigning 2>/dev/null || true)"
+  if printf '%s\n' "${identities}" | grep -q '0 valid identities found'; then
+    warn "no valid code-signing identities found; build will use ad-hoc signing"
+    return
+  fi
+
+  if [[ -n "${CODESIGNING_IDENTITY:-}" ]]; then
+    info "CODESIGNING_IDENTITY is set"
+  fi
+
+  if [[ -n "${identities}" ]]; then
+    printf '%s\n' "${identities}" | sed 's/^/[macos] signing: /'
+  else
+    warn "could not inspect code-signing identities; build will use ad-hoc signing unless configured"
+  fi
+}
+
+preflight() {
+  PREFLIGHT_FAILURES=0
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    warn "macOS build must run on Darwin"
+    PREFLIGHT_FAILURES=$((PREFLIGHT_FAILURES + 1))
+  fi
+
+  need_cmd git
+  need_cmd python3
+  need_cmd xcode-select
+  need_cmd xcodebuild
+  need_cmd xcrun
+  need_cmd plutil
+  need_cmd codesign
+  need_cmd security
+  need_cmd ditto
+  need_cmd file
+  check_optional_cmd gh
+
+  check_disk_space
+  check_xcode
+  check_qt
+  check_signing
+
+  if [[ "${PREFLIGHT_FAILURES}" -ne 0 ]]; then
+    fail "preflight failed with ${PREFLIGHT_FAILURES} blocking issue(s)"
+  fi
+}
+
+ensure_arm64_host() {
+  if [[ "$(uname -m)" != "arm64" ]]; then
+    fail "arm64 build requested on non-arm64 host ($(uname -m)); universal/x86_64 support is not wired yet"
+  fi
+}
+
+ensure_submodules() {
+  info "syncing submodules"
+  git -C "${REPO_ROOT}" config --local url.https://github.com/.insteadOf git@github.com:
+  git -C "${REPO_ROOT}" submodule sync --recursive
+  git -C "${REPO_ROOT}" submodule update --init --recursive
+}
+
+ensure_build_tools() {
+  if [[ ! -d "${BUILD_TOOLS_DIR}/.git" ]]; then
+    info "cloning ONLYOFFICE/build_tools into ${BUILD_TOOLS_DIR}"
+    git clone --filter=blob:none https://github.com/ONLYOFFICE/build_tools.git "${BUILD_TOOLS_DIR}"
+  fi
+
+  info "checking out build_tools ${BUILD_TOOLS_REV}"
+  git -C "${BUILD_TOOLS_DIR}" fetch --tags origin
+  git -C "${BUILD_TOOLS_DIR}" checkout "${BUILD_TOOLS_REV}"
+}
+
+copy_qt_layout_from_prefix() {
+  local prefix="$1"
+  local target="${QT_DIR}/macos"
+
+  info "creating local Qt layout at ${target} from ${prefix}"
+  rm -rf "${target}"
+  mkdir -p "${target}"
+
+  local item name
+  for item in "${prefix}"/*; do
+    name="$(basename "${item}")"
+    if [[ "${name}" == "mkspecs" ]]; then
+      cp -R "${item}" "${target}/${name}"
+    else
+      ln -s "${item}" "${target}/${name}"
+    fi
+  done
+}
+
+ensure_qt_layout() {
+  if [[ -x "${QT_DIR}/macos/bin/qmake" || -x "${QT_DIR}/clang_64/bin/qmake" ]]; then
+    info "using Qt layout at ${QT_DIR}"
+    return
+  fi
+
+  local homebrew_qt
+  homebrew_qt="$(discover_homebrew_qt || true)"
+  if [[ -z "${homebrew_qt}" ]]; then
+    fail "Qt was not found. Install Qt or set QT_DIR to a layout containing macos/bin/qmake or clang_64/bin/qmake."
+  fi
+
+  copy_qt_layout_from_prefix "${homebrew_qt}"
+}
+
+build_native_payload() {
+  mkdir -p "${LOG_DIR}"
+  info "building native desktop payload via build_tools (${BUILD_TOOLS_PLATFORM})"
+
+  (
+    cd "${BUILD_TOOLS_DIR}"
+    python3 configure.py \
+      --update=0 \
+      --module=desktop \
+      --platform="${BUILD_TOOLS_PLATFORM}" \
+      --qt-dir="${QT_DIR}" \
+      --clean=1 \
+      --git-protocol=https
+    python3 make.py
+  ) 2>&1 | tee "${LOG_DIR}/build-tools-${BUILD_TOOLS_PLATFORM}.log"
+
+  local payload_dir="${BUILD_TOOLS_DIR}/out/${BUILD_TOOLS_PLATFORM}/onlyoffice/desktopeditors"
+  if [[ ! -d "${payload_dir}" ]]; then
+    fail "expected desktop payload was not produced: ${payload_dir}"
+  fi
+
+  info "native payload ready: ${payload_dir}"
+}
+
+build_xcode_app() {
+  mkdir -p "${OUT_DIR}" "${LOG_DIR}"
+
+  if [[ ! -d "${XCODE_PROJECT}" ]]; then
+    fail "Xcode project not found: ${XCODE_PROJECT}"
+  fi
+
+  local sign_identity="${CODESIGNING_IDENTITY:-${CODE_SIGN_IDENTITY:--}}"
+  if [[ -z "${sign_identity}" ]]; then
+    sign_identity="-"
+  fi
+
+  info "building ${PRODUCT_NAME}.app with scheme ${SCHEME}"
+  xcodebuild \
+    -project "${XCODE_PROJECT}" \
+    -scheme "${SCHEME}" \
+    -configuration Release \
+    -derivedDataPath "${DERIVED_DATA_DIR}" \
+    PRODUCT_NAME="${PRODUCT_NAME}" \
+    PRODUCT_BUNDLE_IDENTIFIER="${BUNDLE_ID}" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="${sign_identity}" \
+    CODESIGNING_IDENTITY="${CODESIGNING_IDENTITY:-}" \
+    DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-}" \
+    build 2>&1 | tee "${LOG_DIR}/xcode-${SCHEME}.log"
+
+  local products_dir="${DERIVED_DATA_DIR}/Build/Products/Release"
+  local built_app="${products_dir}/${PRODUCT_NAME}.app"
+  if [[ ! -d "${built_app}" ]]; then
+    local candidate
+    built_app=""
+    for candidate in "${products_dir}"/*.app; do
+      if [[ -d "${candidate}" ]]; then
+        built_app="${candidate}"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "${built_app}" || ! -d "${built_app}" ]]; then
+    fail "Xcode did not produce an app bundle under ${products_dir}"
+  fi
+
+  rm -rf "${OUT_DIR}/${PRODUCT_NAME}.app"
+  ditto "${built_app}" "${OUT_DIR}/${PRODUCT_NAME}.app"
+  info "app exported to ${OUT_DIR}/${PRODUCT_NAME}.app"
+}
+
+verify_app() {
+  local app="${OUT_DIR}/${PRODUCT_NAME}.app"
+  local exe="${app}/Contents/MacOS/${PRODUCT_NAME}"
+
+  if [[ ! -d "${app}" ]]; then
+    fail "app bundle missing: ${app}"
+  fi
+
+  if [[ ! -x "${exe}" ]]; then
+    local candidate
+    exe=""
+    for candidate in "${app}/Contents/MacOS"/*; do
+      if [[ -f "${candidate}" && -x "${candidate}" ]]; then
+        exe="${candidate}"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "${exe}" || ! -x "${exe}" ]]; then
+    fail "app executable missing under ${app}/Contents/MacOS"
+  fi
+
+  info "checking executable architecture"
+  file "${exe}" | tee "${LOG_DIR}/file-${PRODUCT_NAME}.log"
+  file "${exe}" | grep -q 'arm64' || fail "expected arm64 executable: ${exe}"
+
+  info "verifying code signature"
+  codesign --verify --deep --strict --verbose=4 "${app}"
+
+  if [[ "${EO_SKIP_LAUNCH:-0}" == "1" ]]; then
+    info "skipping launch smoke test because EO_SKIP_LAUNCH=1"
+    return
+  fi
+
+  info "running launch smoke test"
+  open -n "${app}"
+  sleep 4
+  if ! pgrep -x "${PRODUCT_NAME}" >/dev/null 2>&1; then
+    fail "launch smoke test did not find a running ${PRODUCT_NAME} process"
+  fi
+  osascript -e "tell application \"${PRODUCT_NAME}\" to quit" >/dev/null 2>&1 || true
+}
+
+main() {
+  case "${ARCH}" in
+    -h|--help|"")
+      usage
+      ;;
+    --check)
+      preflight
+      info "preflight passed"
+      ;;
+    arm64)
+      OUT_DIR="${BUILD_DIR}/deploy/macos/${ARCH}"
+      DERIVED_DATA_DIR="${BUILD_DIR}/deploy/macos/DerivedData/${ARCH}"
+      preflight
+      ensure_arm64_host
+      ensure_submodules
+      ensure_build_tools
+      ensure_qt_layout
+      build_native_payload
+      build_xcode_app
+      verify_app
+      info "macOS ${ARCH} build complete: ${OUT_DIR}/${PRODUCT_NAME}.app"
+      ;;
+    *)
+      usage
+      fail "unsupported macOS architecture: ${ARCH}"
+      ;;
+  esac
+}
+
+main "$@"

--- a/build/macos/build_tools.sha
+++ b/build/macos/build_tools.sha
@@ -1,0 +1,1 @@
+c5f6c2e02b50dfcc5c53a207f9a6cde84896de91

--- a/build/macos/patches/boost-date-time-duration-installed.patch
+++ b/build/macos/patches/boost-date-time-duration-installed.patch
@@ -1,0 +1,12 @@
+diff --git a/boost/date_time/posix_time/posix_time_duration.hpp b/boost/date_time/posix_time/posix_time_duration.hpp
+--- a/boost/date_time/posix_time/posix_time_duration.hpp
++++ b/boost/date_time/posix_time/posix_time_duration.hpp
+@@ -31 +31 @@ namespace posix_time {
+-      time_duration(numeric_cast<hour_type>(h), 0, 0)
++      time_duration(static_cast<hour_type>(h), 0, 0)
+@@ -45 +45 @@ namespace posix_time {
+-      time_duration(0, numeric_cast<min_type>(m),0)
++      time_duration(0, static_cast<min_type>(m),0)
+@@ -59 +59 @@ namespace posix_time {
+-      time_duration(0,0, numeric_cast<sec_type>(s))
++      time_duration(0,0, static_cast<sec_type>(s))

--- a/build/macos/patches/boost-date-time-duration.patch
+++ b/build/macos/patches/boost-date-time-duration.patch
@@ -1,0 +1,12 @@
+diff --git a/include/boost/date_time/posix_time/posix_time_duration.hpp b/include/boost/date_time/posix_time/posix_time_duration.hpp
+--- a/include/boost/date_time/posix_time/posix_time_duration.hpp
++++ b/include/boost/date_time/posix_time/posix_time_duration.hpp
+@@ -31 +31 @@ namespace posix_time {
+-      time_duration(numeric_cast<hour_type>(h), 0, 0)
++      time_duration(static_cast<hour_type>(h), 0, 0)
+@@ -45 +45 @@ namespace posix_time {
+-      time_duration(0, numeric_cast<min_type>(m),0)
++      time_duration(0, static_cast<min_type>(m),0)
+@@ -59 +59 @@ namespace posix_time {
+-      time_duration(0,0, numeric_cast<sec_type>(s))
++      time_duration(0,0, static_cast<sec_type>(s))

--- a/build/macos/patches/libetonyek-clang-compat.patch
+++ b/build/macos/patches/libetonyek-clang-compat.patch
@@ -1,0 +1,26 @@
+diff --git a/src/lib/IWORKTable.cpp b/src/lib/IWORKTable.cpp
+--- a/src/lib/IWORKTable.cpp
++++ b/src/lib/IWORKTable.cpp
+@@ -829,2 +829,2 @@ void IWORKTable::draw(const librevenge::RVNGPropertyList &tableProps, IWORKOutpu
+-      cellProps.insert("librevenge:column", numeric_cast<int>(col));
+-      cellProps.insert("librevenge:row", numeric_cast<int>(r));
++      cellProps.insert("librevenge:column", static_cast<int>(col));
++      cellProps.insert("librevenge:row", static_cast<int>(r));
+@@ -833 +833 @@ void IWORKTable::draw(const librevenge::RVNGPropertyList &tableProps, IWORKOutpu
+-        cellProps.insert("table:number-columns-repeated", numeric_cast<int>(numRepeat));
++        cellProps.insert("table:number-columns-repeated", static_cast<int>(numRepeat));
+@@ -864 +864 @@ void IWORKTable::draw(const librevenge::RVNGPropertyList &tableProps, IWORKOutpu
+-          cellProps.insert("table:number-columns-spanned", numeric_cast<int>(cell.m_columnSpan));
++          cellProps.insert("table:number-columns-spanned", static_cast<int>(cell.m_columnSpan));
+@@ -866 +866 @@ void IWORKTable::draw(const librevenge::RVNGPropertyList &tableProps, IWORKOutpu
+-          cellProps.insert("table:number-rows-spanned", numeric_cast<int>(cell.m_rowSpan));
++          cellProps.insert("table:number-rows-spanned", static_cast<int>(cell.m_rowSpan));
+diff --git a/src/lib/contexts/IWORKPathElement.cpp b/src/lib/contexts/IWORKPathElement.cpp
+--- a/src/lib/contexts/IWORKPathElement.cpp
++++ b/src/lib/contexts/IWORKPathElement.cpp
+@@ -171 +171 @@ void PointPathElement::endOfElement()
+-        getCollector().collectStarPath(size, numeric_cast<unsigned>(get(m_point).m_x), get(m_point).m_y);
++        getCollector().collectStarPath(size, static_cast<unsigned>(get(m_point).m_x), get(m_point).m_y);
+@@ -264 +264 @@ void ScalarPathElement::endOfElement()
+-      getCollector().collectPolygonPath(size, numeric_cast<unsigned>(m_value));
++      getCollector().collectPolygonPath(size, static_cast<unsigned>(m_value));

--- a/build/macos/patches/odf-border-width-clang-compat.patch
+++ b/build/macos/patches/odf-border-width-clang-compat.patch
@@ -1,0 +1,12 @@
+diff --git a/OdfFile/Reader/Converter/pptx_table_context.cpp b/OdfFile/Reader/Converter/pptx_table_context.cpp
+--- a/OdfFile/Reader/Converter/pptx_table_context.cpp
++++ b/OdfFile/Reader/Converter/pptx_table_context.cpp
+@@ -316 +316 @@ void process_border(pptx_border_edge & borderEdge, _CP_OPT(odf_types::border_sty
+-		borderEdge.width = boost::lexical_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu));
++		borderEdge.width = static_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu));
+diff --git a/OdfFile/Reader/Converter/xlsx_borders.cpp b/OdfFile/Reader/Converter/xlsx_borders.cpp
+--- a/OdfFile/Reader/Converter/xlsx_borders.cpp
++++ b/OdfFile/Reader/Converter/xlsx_borders.cpp
+@@ -110 +110 @@ void process_border(xlsx_border_edge & borderEdge, const _CP_OPT(border_style) &
+-		borderEdge.width = boost::lexical_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu));
++		borderEdge.width = static_cast<int>(borderStyle->get_length().get_value_unit(odf_types::length::emu));


### PR DESCRIPTION
## Summary

- Keep the existing Linux flow unchanged: `cd DesktopEditors/build` followed by
  `docker buildx bake`.
- Document a parallel host-macOS flow under `build/`.
- Add `build/macos/build.sh` as the single macOS build entrypoint for Apple
  Silicon.
- Standardize output under `build/deploy/macos/arm64/Euro-Office.app`.
- Add preflight checks for macOS, Xcode, disk space, Qt, GitHub CLI, and signing
  identity availability.
- Add `DESKTOP_APPS_DIR` so the macOS build can be tested against the matching
  `desktop-apps` branding branch before the upstream submodule pointer is
  advanced.

## macOS command

```sh
cd DesktopEditors/build
./macos/build.sh --check
DESKTOP_APPS_DIR=/path/to/desktop-apps ./macos/build.sh arm64
```

## Validation

- `bash -n build/macos/build.sh`
- `git diff --check`
- `./macos/build.sh --check`

Local preflight on Apple Silicon with Xcode 26.4.1 correctly detected:

- Xcode is installed and selected.
- `gh` is available.
- No Developer ID signing identity is installed, so local builds should use
  ad-hoc signing.
- The current machine is not ready for a full native build yet: only about 10GiB
  free under the workspace and Qt is not installed/configured.

## Notes

This intentionally does not add a fake Docker build for macOS. Xcode builds need
a macOS host.

Depends on Euro-Office/desktop-apps#16 for the Euro-Office macOS app branding.
After that PR lands, `DesktopEditors` can advance its `desktop-apps` submodule
pointer to the upstream branding commit.
