### PR TITLE
refactor: add possibility to reduce memory load at linux builds

### DIFF
--- a/build/linux/README.md
+++ b/build/linux/README.md
@@ -58,6 +58,28 @@ cd build/linux
 ./build.sh
 ```
 
+### Low-RAM mode (recommended on 16 GB hosts)
+
+The script now auto-selects a conservative CMake/Ninja parallelism level from the
+host's available RAM and CPU count, and runs `desktop-common` and `packages` in
+two sequential bake invocations to reduce peak memory usage.
+
+Current heuristic:
+
+- about **1 job per 8 GiB available RAM**
+- never less than `1`
+- never more than the host CPU count
+- capped at `4` to stay conservative
+
+You can override parallelism explicitly:
+
+```sh
+cd build/linux
+CMAKE_BUILD_PARALLEL_LEVEL=1 ./build.sh   # minimum RAM, slowest build
+# or
+CMAKE_BUILD_PARALLEL_LEVEL=3 ./build.sh   # faster, uses more RAM
+```
+
 ## How the desktop image is built
 
 The desktop stage (in the bake Dockerfile) follows the standard sequence:

--- a/build/linux/build.sh
+++ b/build/linux/build.sh
@@ -12,9 +12,51 @@ COMPANY_NAME="Euro-Office"
 PRODUCT_NAME="Desktop Editors"
 GIT_COMMIT=$(git rev-parse --short HEAD)
 
+detect_build_parallel_level() {
+       local cpu_count mem_kib mem_mib jobs
+
+       cpu_count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 1)
+       mem_kib=$(awk '/MemAvailable:/ { print $2; exit } /MemTotal:/ { print $2; exit }' /proc/meminfo 2>/dev/null || echo 0)
+
+       if [[ -z "${mem_kib}" || "${mem_kib}" -le 0 ]]; then
+              mem_mib=0
+              jobs=1
+       else
+              mem_mib=$((mem_kib / 1024))
+              jobs=$((mem_mib / 8192))
+              if [[ "${jobs}" -lt 1 ]]; then
+                     jobs=1
+              fi
+       fi
+
+       if [[ "${jobs}" -gt "${cpu_count}" ]]; then
+              jobs="${cpu_count}"
+       fi
+
+       if [[ "${jobs}" -gt 4 ]]; then
+              jobs=4
+       fi
+
+       printf '%s\n' "${jobs}"
+}
+
+if [[ -z "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
+       CMAKE_BUILD_PARALLEL_LEVEL=$(detect_build_parallel_level)
+       echo "Auto-selected CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL} based on host RAM/CPU"
+else
+       echo "Using CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL} from environment"
+fi
+
 export NEXTCLOUD_USER NEXTCLOUD_PASS REGISTRY TAG PRODUCT_VERSION \
-       BUILD_NUMBER BRANDING_DIR COMPANY_NAME PRODUCT_NAME GIT_COMMIT
+       BUILD_NUMBER BRANDING_DIR COMPANY_NAME PRODUCT_NAME GIT_COMMIT \
+       CMAKE_BUILD_PARALLEL_LEVEL
+
+# Build the common payload first, then package the Linux desktop build.
+# Splitting phases reduces peak RAM pressure compared to a single combined bake.
+docker buildx bake -f ../docker-bake.hcl desktop-common \
+       --set "*.context=../.." \
+       --set "core-wasm.args.CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}"
 
 docker buildx bake -f ../docker-bake.hcl -f docker-bake.hcl packages \
-       --set "desktop-linux.contexts.desktop-common=target:desktop-common" \
-       --set "*.context=../.."
+       --set "*.context=../.." \
+       --set "desktop-linux.args.CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}"


### PR DESCRIPTION
## Description
The current Linux build path for DesktopEditors is too memory-aggressive for common developer hardware, especially notebooks with 16 GB RAM. On such systems, the build can consume nearly all available memory, trigger OOM conditions, or make the machine unresponsive.